### PR TITLE
Fix build memory job calculation

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
       - name: Cleanup /usr/local
@@ -50,7 +50,7 @@ jobs:
           xcrun llvm-cov show --format=html --output-dir=covreport --ignore-filename-regex=vendor/ --instr-profile=cov.profdata $OBJ_FILES
           xcrun llvm-cov report --ignore-filename-regex=vendor/ --instr-profile=cov.profdata $OBJ_FILES
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: code-coverage-report
           path: covreport/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
       - name: Cleanup /usr/local

--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,19 @@ Release 2.13.0 (unreleased)
     - Fix trace mode on arm64 for macOS > 14.
       (#66358, cal in aacd364)
 
+Release 2.12.6 (unreleased)
+    - Fixed potential unreliable application of network proxy settings
+      with background fetches. (jmr in 6d9edb0)
+
+    - Fixed occasional failure to sync the PortIndex, which required
+      portindex to run locally. (fhgwright in 928dc47)
+
+    - Added documentation for the 'none' option for 'port select'.
+      (cvengler in 1552e82)
+
+    - Various reliability improvements for trace mode.
+      (cal in 6dda4cc, 1db3e7f, bea36d7)
+
 Release 2.12.5 (2026-04-22 by jmr)
     - Fixed upgrade --force sometimes failing when an archive cannot be
       fetched, instead of falling back to building from source.

--- a/ChangeLog
+++ b/ChangeLog
@@ -33,7 +33,7 @@ Release 2.13.0 (unreleased)
     - Fix trace mode on arm64 for macOS > 14.
       (#66358, cal in aacd364)
 
-Release 2.12.6 (unreleased)
+Release 2.12.6 (2026-08-26 by jmr)
     - Fixed potential unreliable application of network proxy settings
       with background fetches. (jmr in 6d9edb0)
 

--- a/config/RELEASE_URL
+++ b/config/RELEASE_URL
@@ -1,1 +1,1 @@
-https://github.com/macports/macports-base/releases/tag/v2.12.5
+https://github.com/macports/macports-base/releases/tag/v2.12.6

--- a/doc/macports.conf.5
+++ b/doc/macports.conf.5
@@ -288,7 +288,7 @@ T}
 .PP
 buildmakejobs
 .RS 4
-Number of simultaneous make jobs (commands) to use when building ports\&. 0 is a special value meaning "the number of CPU cores or the number of GB of physical memory plus one, whichever is less\&."
+Number of simultaneous make jobs (commands) to use when building ports\&. 0 is a special value meaning "the number of CPU cores or physical memory divided by build\&.mem_per_job (1024 MiB by default), whichever is less\&."
 .TS
 tab(:);
 lt lt.

--- a/doc/macports.conf.5.txt
+++ b/doc/macports.conf.5.txt
@@ -109,8 +109,8 @@ buildnicevalue::
 
 buildmakejobs::
     Number of simultaneous make jobs (commands) to use when building ports. 0 is
-    a special value meaning "the number of CPU cores or the number of GB of
-    physical memory plus one, whichever is less."
+    a special value meaning "the number of CPU cores or physical memory
+    divided by build.mem_per_job (1024 MiB by default), whichever is less."
     *Default:*;; 0
 
 portautoclean::

--- a/doc/macports.conf.in
+++ b/doc/macports.conf.in
@@ -124,7 +124,7 @@ variants_conf       	@MPCONFIGDIR_EXPANDED@/variants.conf
 # Number of simultaneous make(1) jobs to use when building ports. If set
 # to 0, the number of jobs will be the lesser of:
 # - number of automatically-detected CPU cores
-# - gigabytes of physical memory + 1
+# - physical memory divided by build.mem_per_job (1024 MiB by default)
 #buildmakejobs       	0
 
 # umask value to use when a port installs its files.

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -7557,14 +7557,19 @@ proc macports::get_parallel_jobs {{mem_restrict yes} {mem_per_job 1024}} {
     variable buildmakejobs; variable os_platform
     if {[string is integer -strict $buildmakejobs] && $buildmakejobs > 0} {
         set jobs $buildmakejobs
-    } elseif {$os_platform eq "darwin" && $buildmakejobs == 0
-              && ![catch {sysctl hw.activecpu} cpus]} {
-        set jobs $cpus
-        if {$mem_restrict && [string is integer -strict $mem_per_job]
-                && $mem_per_job > 0 && ![catch {sysctl hw.memsize} memsize]} {
-            set mem_jobs [expr {$memsize / ($mem_per_job * 1024 * 1024)}]
-            if {$jobs > $mem_jobs} {
-                set jobs $mem_jobs
+    } elseif {$os_platform eq "darwin" && $buildmakejobs == 0} {
+        if {[catch {sysctl hw.activecpu} cpus]} {
+            set jobs 2
+            ui_warn "failed to determine the number of available CPUs (probably not supported on this platform)"
+            ui_warn "defaulting to $jobs jobs, consider setting buildmakejobs to a nonzero value in macports.conf"
+        } else {
+            set jobs $cpus
+            if {$mem_restrict && [string is integer -strict $mem_per_job]
+                    && $mem_per_job > 0 && ![catch {sysctl hw.memsize} memsize]} {
+                set mem_jobs [expr {$memsize / ($mem_per_job * 1024 * 1024)}]
+                if {$jobs > $mem_jobs} {
+                    set jobs $mem_jobs
+                }
             }
         }
     } else {

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -7551,20 +7551,27 @@ proc macports::unobscure_maintainers {list} {
 }
 
 # Get actual number of parallel jobs based on buildmakejobs, which may
-# be 0 for automatic selection.
-proc macports::get_parallel_jobs {{mem_restrict yes}} {
+# be 0 for automatic selection. When memory restriction is enabled,
+# mem_per_job is measured in MiB.
+proc macports::get_parallel_jobs {{mem_restrict yes} {mem_per_job 1024}} {
     variable buildmakejobs; variable os_platform
     if {[string is integer -strict $buildmakejobs] && $buildmakejobs > 0} {
         set jobs $buildmakejobs
     } elseif {$os_platform eq "darwin" && $buildmakejobs == 0
               && ![catch {sysctl hw.activecpu} cpus]} {
         set jobs $cpus
-        if {$mem_restrict && ![catch {sysctl hw.memsize} memsize]
-                && $jobs > $memsize / (1024 * 1024 * 1024) + 1} {
-            set jobs [expr {$memsize / (1024 * 1024 * 1024) + 1}]
+        if {$mem_restrict && [string is integer -strict $mem_per_job]
+                && $mem_per_job > 0 && ![catch {sysctl hw.memsize} memsize]} {
+            set mem_jobs [expr {$memsize / ($mem_per_job * 1024 * 1024)}]
+            if {$jobs > $mem_jobs} {
+                set jobs $mem_jobs
+            }
         }
     } else {
         set jobs 2
+    }
+    if {$jobs < 1} {
+        set jobs 1
     }
     return $jobs
 }

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -2222,6 +2222,7 @@ proc macports::worker_init {workername portpath porturl portbuildpath options va
     $workername alias portfetch::percent_encode portlib::fetch::percent_encode
     $workername alias portfetch::assemble_url portlib::fetch::assemble_url
     $workername alias portfetch::separate_tag portlib::fetch::separate_tag
+    $workername alias portfetch::resolve_mirror_tags portlib::fetch::resolve_mirror_tags
     $workername alias portfetch::get_mirror_site_urls portlib::fetch::get_mirror_site_urls
 
     $workername alias portextract::method_for_suffix portlib::extract::method_for_suffix

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -2417,8 +2417,10 @@ proc macports::get_tar_flags {suffix} {
 # Private helper
 proc macports::_curlwrap_credential_args {site credentials} {
     variable fetch_credentials
-    if {[dict exists $fetch_credentials $site]} {
-        set credentials [dict get $fetch_credentials $site]
+    set url_parts [::uri::split $site]
+    set host [dict getwithdefault $url_parts host {}]
+    if {$host ne {} && [dict exists $fetch_credentials $host]} {
+        set credentials [dict get $fetch_credentials $host]
     }
     return [expr {$credentials ne {} ? [list -u $credentials] : {}}]
 }

--- a/src/pextlib1.0/curl.c
+++ b/src/pextlib1.0/curl.c
@@ -641,6 +641,7 @@ CurlFetchCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
                 break;
             }
         }
+#if LIBCURL_VERSION_NUM >= 0x071304
         if (no_proxy) {
             theCurlCode = curl_easy_setopt(theHandle, CURLOPT_NOPROXY, no_proxy);
             if (theCurlCode != CURLE_OK) {
@@ -648,6 +649,7 @@ CurlFetchCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
                 break;
             }
         }
+#endif
 
 		/* -L option */
 		theCurlCode = curl_easy_setopt(theHandle, CURLOPT_FOLLOWLOCATION, 1);
@@ -1436,6 +1438,7 @@ CurlGetSizeCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
                 break;
             }
         }
+#if LIBCURL_VERSION_NUM >= 0x071304
         if (no_proxy) {
             theCurlCode = curl_easy_setopt(theHandle, CURLOPT_NOPROXY, no_proxy);
             if (theCurlCode != CURLE_OK) {
@@ -1443,6 +1446,7 @@ CurlGetSizeCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
                 break;
             }
         }
+#endif
 
 		/* -L option */
 		theCurlCode = curl_easy_setopt(theHandle, CURLOPT_FOLLOWLOCATION, 1);

--- a/src/port1.0/fetch_common.tcl
+++ b/src/port1.0/fetch_common.tcl
@@ -35,6 +35,7 @@ package require Pextlib 1.0
 namespace eval portfetch {
     variable urlmap
     array set urlmap {}
+    variable tagged_url_re {([a-zA-Z]+://.+/?):([0-9A-Za-z_-]+)$}
 }
 
 # For a given mirror site type, e.g. "gnu" or "x11", check to see if there's a
@@ -50,43 +51,33 @@ proc portfetch::mirror_sites {mirrors tag subdir mirrorscmd} {
         return [list]
     }
 
-    set ret [list]
-    set name_re {\$(?:name\y|\{name\})}
-    foreach element $sites_entry {
-
-        # here we have the chance to take a look at tags, that possibly
-        # have been assigned in mirror_sites.tcl
-        lassign [separate_tag $element] element mirror_tag
-
-        # if the URL has $name embedded, kill any mirror_tag that may have been added
-        # since a mirror_tag and $name are incompatible
-        if {$mirror_tag ne "" && [regexp $name_re $element]} {
-            set mirror_tag ""
-        }
-
-        if {$mirror_tag eq "mirror"} {
-            set thesubdir ${dist_subdir}
-        } elseif {$subdir eq "" && $mirror_tag ne "nosubdir"} {
-            set thesubdir ${name}
-        } else {
-            set thesubdir ${subdir}
-        }
-
-        # parse an embedded $name. if present, remove the subdir
-        if {[regsub $name_re $element $thesubdir element] > 0} {
-            set thesubdir ""
-        }
-
-        if {$tag ne ""} {
-            append element "${thesubdir}:${tag}"
-        } else {
-            append element "${thesubdir}"
-        }
-
-        lappend ret $element
+    lmap element $sites_entry {
+        resolve_mirror_tags $element $subdir $tag $name $dist_subdir
     }
+}
 
-    return $ret
+# Resolve any tags present in a user-defined site
+# a single tag is taken to be a mirror option tag (:nosubdir, :mirror)
+# an optional second tag acts like a tag on a url in master_sites
+proc portfetch::resolve_env_site {site} {
+    variable tagged_url_re
+    set resolved_is_tagged 0
+    if {[regexp $tagged_url_re $site]} {
+        global name dist_subdir
+        # At least one tag, check for a second
+        lassign [separate_tag $site] element tag
+        if {[regexp $tagged_url_re $element]} {
+            # two tags
+            set resolved_element [resolve_mirror_tags $element {} $tag $name $dist_subdir]
+            resolved_is_tagged 1
+        } else {
+            # single tag
+            set resolved_element [resolve_mirror_tags $site {} {} $name $dist_subdir]
+        }
+    } else {
+        set resolved_element $site
+    }
+    return [list $resolved_element $resolved_is_tagged]
 }
 
 # Checks sites.
@@ -98,7 +89,7 @@ proc portfetch::checksites {sitelists mirrorscmd} {
     global env
     variable urlmap
     set url_re {([a-zA-Z]+://.+)}
-    set tagged_url_re {([a-zA-Z]+://.+/?):([0-9A-Za-z_-]+)$}
+    variable tagged_url_re
 
     foreach {listname extras} $sitelists {
         upvar #0 $listname $listname
@@ -113,12 +104,15 @@ proc portfetch::checksites {sitelists mirrorscmd} {
         if {[llength $extras] >= 2} {
             lassign $extras sglobal senv
             if {[info exists env($senv)]} {
-                set full_list [list {*}$env($senv) {*}$full_list]
-                foreach env_site $env($senv) {
-                    if {![regexp $tagged_url_re $env_site]} {
-                        lappend untagged_env_sites $env_site
+                set resolved_senv [list]
+                foreach s $env($senv) {
+                    lassign [resolve_env_site $s] resolved_element resolved_is_tagged
+                    lappend resolved_senv $resolved_element
+                    if {!$resolved_is_tagged} {
+                        lappend untagged_env_sites $resolved_element
                     }
                 }
+                set full_list [list {*}$resolved_senv {*}$full_list]
             }
             if {$sglobal ne ""} {
                 set full_list [list $sglobal {*}$full_list]

--- a/src/port1.0/portbuild.tcl
+++ b/src/port1.0/portbuild.tcl
@@ -136,33 +136,15 @@ proc portbuild::build_getmaketype {args} {
 
 proc portbuild::build_getjobs {args} {
     global buildmakejobs use_parallel_build
-    set jobs $buildmakejobs
     # If parallel disabled disabled, return 1
     if {![tbool use_parallel_build]} {
         ui_debug "port disallows a parallel build, setting build jobs to 1"
-        set jobs 1
+        return 1
     }
-    # if set to '0', use the number of cores for the number of jobs
-    if {$jobs == 0} {
-        macports_try -pass_signal {
-            set jobs [sysctl hw.activecpu]
-        } on error {} {
-            set jobs 2
-            ui_warn "failed to determine the number of available CPUs (probably not supported on this platform)"
-            ui_warn "defaulting to $jobs jobs, consider setting buildmakejobs to a nonzero value in macports.conf"
-        }
-
-        macports_try -pass_signal {
-            set memsize [sysctl hw.memsize]
-            global build.mem_per_job
-            set jobs_limit_mem [expr {int($memsize / (${build.mem_per_job} * 1024 * 1024)) + 1}]
-            if {$jobs > $jobs_limit_mem} {
-                set jobs $jobs_limit_mem
-            }
-        } on error {} {}
-    }
+    global build.mem_per_job
+    set jobs [macports::get_parallel_jobs yes ${build.mem_per_job}]
     if {![string is integer -strict $jobs] || $jobs <= 1} {
-        set jobs 1
+        return 1
     }
     return $jobs
 }

--- a/src/port1.0/portbuild.tcl
+++ b/src/port1.0/portbuild.tcl
@@ -136,11 +136,22 @@ proc portbuild::build_getmaketype {args} {
 
 proc portbuild::build_getjobs {args} {
     global buildmakejobs use_parallel_build
-    # If parallel disabled disabled, return 1
+    # If parallel builds are disabled, return 1.
     if {![tbool use_parallel_build]} {
         ui_debug "port disallows a parallel build, setting build jobs to 1"
         return 1
     }
+
+    # Explicitly configured job counts belong to this port interpreter. The
+    # shared helper uses the macports namespace value, so only delegate the
+    # automatic (zero) case to it.
+    if {[string is integer -strict $buildmakejobs] && $buildmakejobs > 0} {
+        return $buildmakejobs
+    }
+    if {![string is integer -strict $buildmakejobs] || $buildmakejobs < 0} {
+        return 1
+    }
+
     global build.mem_per_job
     set jobs [macports::get_parallel_jobs yes ${build.mem_per_job}]
     if {![string is integer -strict $jobs] || $jobs <= 1} {

--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -875,9 +875,10 @@ proc portconfigure::get_compiler_fallback {} {
 }
 #
 proc portconfigure::get_fortran_fallback {} {
+    global porturl
     set compilers [list]
     set vmin [get_min_gfortran]
-    foreach c [get_gcc_compilers] {
+    foreach c [get_gcc_compilers $porturl] {
         set v    [lindex [split $c -] 2]
         if {[vercmp ${vmin} $v] <= 0} {
             lappend compilers $c

--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -762,6 +762,11 @@ proc portconfigure::g95_ok {} {
     return yes
 }
 
+proc compiler.command_line_tools_version {compiler} {
+    global configure.developer_dir
+    portconfigure::get_system_compiler_version $compiler ${configure.developer_dir}
+}
+
 # internal function to choose compiler fallback list based on platform
 proc portconfigure::get_compiler_fallback {} {
     global default_compilers porturl xcodeversion os.platform \

--- a/src/port1.0/portlivecheck_run.tcl
+++ b/src/port1.0/portlivecheck_run.tcl
@@ -164,6 +164,7 @@ proc _livecheck_main {{async no}} {
             # Async fetch code appends .TMP for in-progress files. No real
             # need to rename it here when it's done.
             file rename $tempfilename ${tempfilename}.TMP
+            chownAsRoot ${tempfilename}.TMP
         }
     }
 

--- a/src/port1.0/tests/portbuild.test
+++ b/src/port1.0/tests/portbuild.test
@@ -82,6 +82,20 @@ test build_getjobs_auto_memlimited {
     return [portbuild::build_getjobs]
 } -result 4
 
+test build_getjobs_auto_memminimum {
+    Verify that portbuild::build_getjobs selects at least one executor when available memory is below the per-job limit
+} -setup $build_getjobs_fixture_setup -cleanup $build_getjobs_fixture_cleanup -body {
+    global buildmakejobs
+
+    set buildmakejobs 0
+    set _activecpus 8
+    set _activecpus_fail no
+    set _memsize 0.5
+    set _memsize_fail no
+
+    return [portbuild::build_getjobs]
+} -result 1
+
 test build_getjobs_port_memlimit {
     Verify that build.mem_per_job caps automatic parallel jobs using floor division.
 } -setup $build_getjobs_fixture_setup -cleanup $build_getjobs_fixture_cleanup -body {

--- a/src/port1.0/tests/portbuild.test
+++ b/src/port1.0/tests/portbuild.test
@@ -18,6 +18,11 @@ package require portutil 1.0
 package require portbuild 1.0
 
 set build_getjobs_fixture_setup {
+    global use_parallel_build build.mem_per_job
+
+    set use_parallel_build yes
+    set build.mem_per_job 1024
+
     # Move away sysctl and replace it with our own implementation
     rename sysctl sysctl_backup
     proc sysctl {sysctlname} {
@@ -42,8 +47,6 @@ set build_getjobs_fixture_setup {
     }
 }
 set build_getjobs_fixture_cleanup {
-    global buildmakejobs use_parallel_build build.mem_per_job
-
     # Restore modified state
     rename sysctl ""
     rename sysctl_backup sysctl

--- a/src/port1.0/tests/portbuild.test
+++ b/src/port1.0/tests/portbuild.test
@@ -96,6 +96,20 @@ test build_getjobs_auto_memminimum {
     return [portbuild::build_getjobs]
 } -result 1
 
+test get_parallel_jobs_auto_memminimum {
+    Verify that macports::get_parallel_jobs itself selects at least one executor when available memory is below the per-job limit
+} -setup $build_getjobs_fixture_setup -cleanup $build_getjobs_fixture_cleanup -body {
+    global buildmakejobs build.mem_per_job
+
+    set buildmakejobs 0
+    set _activecpus 8
+    set _activecpus_fail no
+    set _memsize 0.5
+    set _memsize_fail no
+
+    return [macports::get_parallel_jobs yes ${build.mem_per_job}]
+} -result 1
+
 test build_getjobs_port_memlimit {
     Verify that build.mem_per_job caps automatic parallel jobs using floor division.
 } -setup $build_getjobs_fixture_setup -cleanup $build_getjobs_fixture_cleanup -body {

--- a/src/port1.0/tests/portbuild.test
+++ b/src/port1.0/tests/portbuild.test
@@ -42,7 +42,7 @@ set build_getjobs_fixture_setup {
     }
 }
 set build_getjobs_fixture_cleanup {
-    global buildmakejobs
+    global buildmakejobs use_parallel_build build.mem_per_job
 
     # Restore modified state
     rename sysctl ""
@@ -77,7 +77,34 @@ test build_getjobs_auto_memlimited {
     set _memsize_fail no
 
     return [portbuild::build_getjobs]
-} -result 5
+} -result 4
+
+test build_getjobs_port_memlimit {
+    Verify that build.mem_per_job caps automatic parallel jobs using floor division.
+} -setup $build_getjobs_fixture_setup -cleanup $build_getjobs_fixture_cleanup -body {
+    global buildmakejobs use_parallel_build build.mem_per_job
+
+    set buildmakejobs 0
+    set use_parallel_build yes
+    set build.mem_per_job 2048
+    set _activecpus 8
+    set _activecpus_fail no
+    set _memsize 7
+    set _memsize_fail no
+
+    return [portbuild::build_getjobs]
+} -result 3
+
+test build_getjobs_parallel_disabled {
+    Verify that a Portfile can always disable parallel builds.
+} -setup $build_getjobs_fixture_setup -cleanup $build_getjobs_fixture_cleanup -body {
+    global buildmakejobs use_parallel_build
+
+    set buildmakejobs 42
+    set use_parallel_build no
+
+    return [portbuild::build_getjobs]
+} -result 1
 
 test build_getjobs_configured {
     Verify that portbuild::build_getjobs correctly returns the number of configured parallel executors

--- a/src/portlib1.0/portlib.tcl
+++ b/src/portlib1.0/portlib.tcl
@@ -1829,7 +1829,7 @@ namespace eval portlib {
         {
             # Get the active port from the registry
             set entries [registry::entry installed $portname]
-            if {[llength $entries < 1]} {
+            if {[llength $entries] < 1} {
                 ui_warn "recursive_collect_deps: '$portname' is registered as a dependency but is not active"
                 return $depsfound
             }

--- a/src/portlib1.0/portlib.tcl
+++ b/src/portlib1.0/portlib.tcl
@@ -1236,6 +1236,43 @@ namespace eval portlib {
             }
             return [list $element $tag]
         }
+
+        # Take possibly tagged URL and return a version with any tag
+        # affecting the subdir removed and the appropriate subdir added.
+        # Example: https://foo.bar/:mirror becomes https://foo.bar/${dist_subdir}
+        variable name_re {\$(?:name\y|\{name\})}
+        proc resolve_mirror_tags {element subdir tag name dist_subdir} {
+            variable name_re
+            # here we have the chance to take a look at tags, that possibly
+            # have been assigned in mirror_sites.tcl
+            lassign [separate_tag $element] element mirror_tag
+
+            # if the URL has $name embedded, kill any mirror_tag that may have been added
+            # since a mirror_tag and $name are incompatible
+            if {$mirror_tag ne "" && [regexp $name_re $element]} {
+                set mirror_tag ""
+            }
+
+            if {$mirror_tag eq "mirror"} {
+                set thesubdir ${dist_subdir}
+            } elseif {$subdir eq "" && $mirror_tag ne "nosubdir"} {
+                set thesubdir ${name}
+            } else {
+                set thesubdir ${subdir}
+            }
+
+            # parse an embedded $name. if present, remove the subdir
+            if {[regsub $name_re $element $thesubdir element] > 0} {
+                set thesubdir ""
+            }
+
+            if {$tag ne ""} {
+                append element ${thesubdir}:${tag}
+            } else {
+                append element $thesubdir
+            }
+            return $element
+        }
     }
 
     namespace eval util {

--- a/src/portlib1.0/portlib.tcl
+++ b/src/portlib1.0/portlib.tcl
@@ -1899,7 +1899,7 @@ namespace eval portlib {
             }
 
             if {${os_platform} eq "darwin"} {
-                set dscl [findBinary dscl $::portlib::autoconf::dscl_path]
+                set dscl [macports::findBinary dscl $::portlib::autoconf::dscl_path]
                 set failed? 0
                 macports_try {
                     exec -ignorestderr $dscl . -create /Users/${username} UniqueID ${uid}
@@ -2015,7 +2015,7 @@ namespace eval portlib {
             }
 
             if {${os_platform} eq "darwin"} {
-                set dscl [findBinary dscl $::portlib::autoconf::dscl_path]
+                set dscl [macports::findBinary dscl $::portlib::autoconf::dscl_path]
                 set failed? 0
                 macports_try {
                     exec -ignorestderr $dscl . -create /Groups/${groupname} Password ${passwd}


### PR DESCRIPTION
Closes #35.

Corrects memory-limited parallel job calculation, preserves configured and minimum automatic job behavior, honors `build.mem_per_job`, and adds targeted regression coverage.

Validation:

- all 10 GitHub Actions checks pass across macOS 14, macOS 15, macOS 26, and Ubuntu
- `portbuild.test`: 11 passed, including a direct mutation-sensitive assertion for the shared helper's minimum automatic job count
- review-fix commits eliminate test-state leakage and restore the documented configured-job behavior
- independent delta review: PASS at head `36ef1509c`
