### PR TITLE
Test portindex deferred runtime loading

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
       - name: Cleanup /usr/local
@@ -50,7 +50,7 @@ jobs:
           xcrun llvm-cov show --format=html --output-dir=covreport --ignore-filename-regex=vendor/ --instr-profile=cov.profdata $OBJ_FILES
           xcrun llvm-cov report --ignore-filename-regex=vendor/ --instr-profile=cov.profdata $OBJ_FILES
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: code-coverage-report
           path: covreport/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
       - name: Cleanup /usr/local

--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,19 @@ Release 2.13.0 (unreleased)
     - Fix trace mode on arm64 for macOS > 14.
       (#66358, cal in aacd364)
 
+Release 2.12.6 (unreleased)
+    - Fixed potential unreliable application of network proxy settings
+      with background fetches. (jmr in 6d9edb0)
+
+    - Fixed occasional failure to sync the PortIndex, which required
+      portindex to run locally. (fhgwright in 928dc47)
+
+    - Added documentation for the 'none' option for 'port select'.
+      (cvengler in 1552e82)
+
+    - Various reliability improvements for trace mode.
+      (cal in 6dda4cc, 1db3e7f, bea36d7)
+
 Release 2.12.5 (2026-04-22 by jmr)
     - Fixed upgrade --force sometimes failing when an archive cannot be
       fetched, instead of falling back to building from source.

--- a/ChangeLog
+++ b/ChangeLog
@@ -33,7 +33,7 @@ Release 2.13.0 (unreleased)
     - Fix trace mode on arm64 for macOS > 14.
       (#66358, cal in aacd364)
 
-Release 2.12.6 (unreleased)
+Release 2.12.6 (2026-08-26 by jmr)
     - Fixed potential unreliable application of network proxy settings
       with background fetches. (jmr in 6d9edb0)
 

--- a/config/RELEASE_URL
+++ b/config/RELEASE_URL
@@ -1,1 +1,1 @@
-https://github.com/macports/macports-base/releases/tag/v2.12.5
+https://github.com/macports/macports-base/releases/tag/v2.12.6

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -2222,6 +2222,7 @@ proc macports::worker_init {workername portpath porturl portbuildpath options va
     $workername alias portfetch::percent_encode portlib::fetch::percent_encode
     $workername alias portfetch::assemble_url portlib::fetch::assemble_url
     $workername alias portfetch::separate_tag portlib::fetch::separate_tag
+    $workername alias portfetch::resolve_mirror_tags portlib::fetch::resolve_mirror_tags
     $workername alias portfetch::get_mirror_site_urls portlib::fetch::get_mirror_site_urls
 
     $workername alias portextract::method_for_suffix portlib::extract::method_for_suffix

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -2417,8 +2417,10 @@ proc macports::get_tar_flags {suffix} {
 # Private helper
 proc macports::_curlwrap_credential_args {site credentials} {
     variable fetch_credentials
-    if {[dict exists $fetch_credentials $site]} {
-        set credentials [dict get $fetch_credentials $site]
+    set url_parts [::uri::split $site]
+    set host [dict getwithdefault $url_parts host {}]
+    if {$host ne {} && [dict exists $fetch_credentials $host]} {
+        set credentials [dict get $fetch_credentials $host]
     }
     return [expr {$credentials ne {} ? [list -u $credentials] : {}}]
 }

--- a/src/pextlib1.0/curl.c
+++ b/src/pextlib1.0/curl.c
@@ -641,6 +641,7 @@ CurlFetchCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
                 break;
             }
         }
+#if LIBCURL_VERSION_NUM >= 0x071304
         if (no_proxy) {
             theCurlCode = curl_easy_setopt(theHandle, CURLOPT_NOPROXY, no_proxy);
             if (theCurlCode != CURLE_OK) {
@@ -648,6 +649,7 @@ CurlFetchCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
                 break;
             }
         }
+#endif
 
 		/* -L option */
 		theCurlCode = curl_easy_setopt(theHandle, CURLOPT_FOLLOWLOCATION, 1);
@@ -1436,6 +1438,7 @@ CurlGetSizeCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
                 break;
             }
         }
+#if LIBCURL_VERSION_NUM >= 0x071304
         if (no_proxy) {
             theCurlCode = curl_easy_setopt(theHandle, CURLOPT_NOPROXY, no_proxy);
             if (theCurlCode != CURLE_OK) {
@@ -1443,6 +1446,7 @@ CurlGetSizeCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
                 break;
             }
         }
+#endif
 
 		/* -L option */
 		theCurlCode = curl_easy_setopt(theHandle, CURLOPT_FOLLOWLOCATION, 1);

--- a/src/port1.0/fetch_common.tcl
+++ b/src/port1.0/fetch_common.tcl
@@ -35,6 +35,7 @@ package require Pextlib 1.0
 namespace eval portfetch {
     variable urlmap
     array set urlmap {}
+    variable tagged_url_re {([a-zA-Z]+://.+/?):([0-9A-Za-z_-]+)$}
 }
 
 # For a given mirror site type, e.g. "gnu" or "x11", check to see if there's a
@@ -50,43 +51,33 @@ proc portfetch::mirror_sites {mirrors tag subdir mirrorscmd} {
         return [list]
     }
 
-    set ret [list]
-    set name_re {\$(?:name\y|\{name\})}
-    foreach element $sites_entry {
-
-        # here we have the chance to take a look at tags, that possibly
-        # have been assigned in mirror_sites.tcl
-        lassign [separate_tag $element] element mirror_tag
-
-        # if the URL has $name embedded, kill any mirror_tag that may have been added
-        # since a mirror_tag and $name are incompatible
-        if {$mirror_tag ne "" && [regexp $name_re $element]} {
-            set mirror_tag ""
-        }
-
-        if {$mirror_tag eq "mirror"} {
-            set thesubdir ${dist_subdir}
-        } elseif {$subdir eq "" && $mirror_tag ne "nosubdir"} {
-            set thesubdir ${name}
-        } else {
-            set thesubdir ${subdir}
-        }
-
-        # parse an embedded $name. if present, remove the subdir
-        if {[regsub $name_re $element $thesubdir element] > 0} {
-            set thesubdir ""
-        }
-
-        if {$tag ne ""} {
-            append element "${thesubdir}:${tag}"
-        } else {
-            append element "${thesubdir}"
-        }
-
-        lappend ret $element
+    lmap element $sites_entry {
+        resolve_mirror_tags $element $subdir $tag $name $dist_subdir
     }
+}
 
-    return $ret
+# Resolve any tags present in a user-defined site
+# a single tag is taken to be a mirror option tag (:nosubdir, :mirror)
+# an optional second tag acts like a tag on a url in master_sites
+proc portfetch::resolve_env_site {site} {
+    variable tagged_url_re
+    set resolved_is_tagged 0
+    if {[regexp $tagged_url_re $site]} {
+        global name dist_subdir
+        # At least one tag, check for a second
+        lassign [separate_tag $site] element tag
+        if {[regexp $tagged_url_re $element]} {
+            # two tags
+            set resolved_element [resolve_mirror_tags $element {} $tag $name $dist_subdir]
+            resolved_is_tagged 1
+        } else {
+            # single tag
+            set resolved_element [resolve_mirror_tags $site {} {} $name $dist_subdir]
+        }
+    } else {
+        set resolved_element $site
+    }
+    return [list $resolved_element $resolved_is_tagged]
 }
 
 # Checks sites.
@@ -98,7 +89,7 @@ proc portfetch::checksites {sitelists mirrorscmd} {
     global env
     variable urlmap
     set url_re {([a-zA-Z]+://.+)}
-    set tagged_url_re {([a-zA-Z]+://.+/?):([0-9A-Za-z_-]+)$}
+    variable tagged_url_re
 
     foreach {listname extras} $sitelists {
         upvar #0 $listname $listname
@@ -113,12 +104,15 @@ proc portfetch::checksites {sitelists mirrorscmd} {
         if {[llength $extras] >= 2} {
             lassign $extras sglobal senv
             if {[info exists env($senv)]} {
-                set full_list [list {*}$env($senv) {*}$full_list]
-                foreach env_site $env($senv) {
-                    if {![regexp $tagged_url_re $env_site]} {
-                        lappend untagged_env_sites $env_site
+                set resolved_senv [list]
+                foreach s $env($senv) {
+                    lassign [resolve_env_site $s] resolved_element resolved_is_tagged
+                    lappend resolved_senv $resolved_element
+                    if {!$resolved_is_tagged} {
+                        lappend untagged_env_sites $resolved_element
                     }
                 }
+                set full_list [list {*}$resolved_senv {*}$full_list]
             }
             if {$sglobal ne ""} {
                 set full_list [list $sglobal {*}$full_list]

--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -875,9 +875,10 @@ proc portconfigure::get_compiler_fallback {} {
 }
 #
 proc portconfigure::get_fortran_fallback {} {
+    global porturl
     set compilers [list]
     set vmin [get_min_gfortran]
-    foreach c [get_gcc_compilers] {
+    foreach c [get_gcc_compilers $porturl] {
         set v    [lindex [split $c -] 2]
         if {[vercmp ${vmin} $v] <= 0} {
             lappend compilers $c

--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -762,6 +762,11 @@ proc portconfigure::g95_ok {} {
     return yes
 }
 
+proc compiler.command_line_tools_version {compiler} {
+    global configure.developer_dir
+    portconfigure::get_system_compiler_version $compiler ${configure.developer_dir}
+}
+
 # internal function to choose compiler fallback list based on platform
 proc portconfigure::get_compiler_fallback {} {
     global default_compilers porturl xcodeversion os.platform \

--- a/src/port1.0/portlivecheck_run.tcl
+++ b/src/port1.0/portlivecheck_run.tcl
@@ -164,6 +164,7 @@ proc _livecheck_main {{async no}} {
             # Async fetch code appends .TMP for in-progress files. No real
             # need to rename it here when it's done.
             file rename $tempfilename ${tempfilename}.TMP
+            chownAsRoot ${tempfilename}.TMP
         }
     }
 

--- a/src/port1.0/portpatch.tcl
+++ b/src/port1.0/portpatch.tcl
@@ -10,6 +10,10 @@ target_requires ${org.macports.patch} main fetch checksum extract
 target_runpkg ${org.macports.patch} portpatch_run
 
 namespace eval portpatch {
+    proc patch_main {args} {
+        package require portpatch_run 1.0
+        return [_patch_main {*}${args}]
+    }
 }
 
 # Add command patch

--- a/src/port1.0/portpatch_run.tcl
+++ b/src/port1.0/portpatch_run.tcl
@@ -32,7 +32,7 @@ package provide portpatch_run 1.0
 
 namespace eval portpatch {
 
-proc patch_main {args} {
+proc _patch_main {args} {
     global UI_PREFIX
 
     # First make sure that patchfiles exists and isn't stubbed out.

--- a/src/port1.0/tests/portpatch.test
+++ b/src/port1.0/tests/portpatch.test
@@ -14,6 +14,13 @@ source ../port_autoconf.tcl
 macports_worker_init
 
 
+test patch_main_deferred {
+    The patch target entry point exists without loading its runtime package.
+} -body {
+    list [package provide portpatch_run] [llength [info commands portpatch::patch_main]]
+} -result {{} 1}
+
+
 test build_getpatchtype {
     Get patch type unit test.
 } -body {

--- a/src/port1.0/tests/portpatch.test
+++ b/src/port1.0/tests/portpatch.test
@@ -15,10 +15,16 @@ macports_worker_init
 
 
 test patch_main_deferred {
-    The patch target entry point exists without loading its runtime package.
+    The patch target entry point loads and forwards to its runtime implementation.
 } -body {
-    list [package provide portpatch_run] [llength [info commands portpatch::patch_main]]
-} -result {{} 1}
+    set before [package provide portpatch_run]
+    set result [portpatch::patch_main]
+    list \
+        $before \
+        $result \
+        [package provide portpatch_run] \
+        [llength [info commands portpatch::_patch_main]]
+} -result {{} 0 1.0 1}
 
 
 test build_getpatchtype {

--- a/src/portlib1.0/portlib.tcl
+++ b/src/portlib1.0/portlib.tcl
@@ -1829,7 +1829,7 @@ namespace eval portlib {
         {
             # Get the active port from the registry
             set entries [registry::entry installed $portname]
-            if {[llength $entries < 1]} {
+            if {[llength $entries] < 1} {
                 ui_warn "recursive_collect_deps: '$portname' is registered as a dependency but is not active"
                 return $depsfound
             }

--- a/src/portlib1.0/portlib.tcl
+++ b/src/portlib1.0/portlib.tcl
@@ -1236,6 +1236,43 @@ namespace eval portlib {
             }
             return [list $element $tag]
         }
+
+        # Take possibly tagged URL and return a version with any tag
+        # affecting the subdir removed and the appropriate subdir added.
+        # Example: https://foo.bar/:mirror becomes https://foo.bar/${dist_subdir}
+        variable name_re {\$(?:name\y|\{name\})}
+        proc resolve_mirror_tags {element subdir tag name dist_subdir} {
+            variable name_re
+            # here we have the chance to take a look at tags, that possibly
+            # have been assigned in mirror_sites.tcl
+            lassign [separate_tag $element] element mirror_tag
+
+            # if the URL has $name embedded, kill any mirror_tag that may have been added
+            # since a mirror_tag and $name are incompatible
+            if {$mirror_tag ne "" && [regexp $name_re $element]} {
+                set mirror_tag ""
+            }
+
+            if {$mirror_tag eq "mirror"} {
+                set thesubdir ${dist_subdir}
+            } elseif {$subdir eq "" && $mirror_tag ne "nosubdir"} {
+                set thesubdir ${name}
+            } else {
+                set thesubdir ${subdir}
+            }
+
+            # parse an embedded $name. if present, remove the subdir
+            if {[regsub $name_re $element $thesubdir element] > 0} {
+                set thesubdir ""
+            }
+
+            if {$tag ne ""} {
+                append element ${thesubdir}:${tag}
+            } else {
+                append element $thesubdir
+            }
+            return $element
+        }
     }
 
     namespace eval util {

--- a/src/portlib1.0/portlib.tcl
+++ b/src/portlib1.0/portlib.tcl
@@ -1899,7 +1899,7 @@ namespace eval portlib {
             }
 
             if {${os_platform} eq "darwin"} {
-                set dscl [findBinary dscl $::portlib::autoconf::dscl_path]
+                set dscl [macports::findBinary dscl $::portlib::autoconf::dscl_path]
                 set failed? 0
                 macports_try {
                     exec -ignorestderr $dscl . -create /Users/${username} UniqueID ${uid}
@@ -2015,7 +2015,7 @@ namespace eval portlib {
             }
 
             if {${os_platform} eq "darwin"} {
-                set dscl [findBinary dscl $::portlib::autoconf::dscl_path]
+                set dscl [macports::findBinary dscl $::portlib::autoconf::dscl_path]
                 set failed? 0
                 macports_try {
                     exec -ignorestderr $dscl . -create /Groups/${groupname} Password ${passwd}

--- a/tests/portindex-no-run-packages.tcl
+++ b/tests/portindex-no-run-packages.tcl
@@ -39,7 +39,7 @@ try {
     }
     set ::env(TCLLIBPATH) [list $poison_dir]
     try {
-        exec $portindex -e -f -o $output_dir $ports_tree
+        exec -ignorestderr $portindex -e -f -o $output_dir $ports_tree 2>@1
         if {![file exists [file join $output_dir PortIndex]]} {
             error "portindex did not create the isolated PortIndex"
         }

--- a/tests/portindex-no-run-packages.tcl
+++ b/tests/portindex-no-run-packages.tcl
@@ -1,0 +1,50 @@
+#!/usr/bin/env tclsh
+
+# Run portindex with every in-tree runtime package poisoned. This checks a full
+# ports tree without executing targets: Portfile parsing must need only the
+# parse-time target packages.
+
+if {$argc != 2} {
+    puts stderr "usage: $argv0 PORTINDEX PORTS_TREE"
+    exit 2
+}
+
+set portindex [file normalize [lindex $argv 0]]
+set ports_tree [file normalize [lindex $argv 1]]
+set top_srcdir [file dirname [file dirname [file normalize [info script]]]]
+
+if {![file executable $portindex] || ![file isdirectory $ports_tree]} {
+    puts stderr "PORTINDEX must be executable and PORTS_TREE must be a directory"
+    exit 2
+}
+
+set temp_channel [file tempfile poison_file]
+close $temp_channel
+file delete $poison_file
+set poison_dir [file normalize "${poison_file}-run-packages"]
+file mkdir $poison_dir
+try {
+    set fd [open [file join $poison_dir pkgIndex.tcl] w]
+    foreach run_file [glob -tails -directory [file join $top_srcdir src port1.0] *_run.tcl] {
+        set runpkg [file rootname $run_file]
+        puts $fd [list package ifneeded $runpkg 1.0 [list error "Runtime package $runpkg loaded while indexing"]]
+    }
+    close $fd
+
+    set had_tcllibpath [info exists ::env(TCLLIBPATH)]
+    if {$had_tcllibpath} {
+        set saved_tcllibpath $::env(TCLLIBPATH)
+    }
+    set ::env(TCLLIBPATH) [list $poison_dir]
+    try {
+        exec $portindex -e $ports_tree
+    } finally {
+        if {$had_tcllibpath} {
+            set ::env(TCLLIBPATH) $saved_tcllibpath
+        } else {
+            unset ::env(TCLLIBPATH)
+        }
+    }
+} finally {
+    file delete -force $poison_dir
+}

--- a/tests/portindex-no-run-packages.tcl
+++ b/tests/portindex-no-run-packages.tcl
@@ -24,6 +24,8 @@ file delete $poison_file
 set poison_dir [file normalize "${poison_file}-run-packages"]
 file mkdir $poison_dir
 try {
+    set output_dir [file join $poison_dir index]
+    file mkdir $output_dir
     set fd [open [file join $poison_dir pkgIndex.tcl] w]
     foreach run_file [glob -tails -directory [file join $top_srcdir src port1.0] *_run.tcl] {
         set runpkg [file rootname $run_file]
@@ -37,7 +39,10 @@ try {
     }
     set ::env(TCLLIBPATH) [list $poison_dir]
     try {
-        exec $portindex -e $ports_tree
+        exec $portindex -e -f -o $output_dir $ports_tree
+        if {![file exists [file join $output_dir PortIndex]]} {
+            error "portindex did not create the isolated PortIndex"
+        }
     } finally {
         if {$had_tcllibpath} {
             set ::env(TCLLIBPATH) $saved_tcllibpath

--- a/tests/test-tclsh.in
+++ b/tests/test-tclsh.in
@@ -16,7 +16,12 @@ fi
 
 # Tcl package search path: vendor libs first, then in-tree src packages
 SRCDIR="@abs_top_builddir@/src"
-export TCLLIBPATH="${DESTROOT}${MP_PREFIX}/lib ${SRCDIR}/macports1.0 ${SRCDIR}/port1.0 ${SRCDIR}/portlib1.0 ${SRCDIR}/pextlib1.0 ${SRCDIR}/registry2.0 ${SRCDIR}/machista1.0 ${SRCDIR}/mpcommon1.0 ${SRCDIR}/package1.0 ${SRCDIR}/portlist1.0"
+TEST_TCLLIBPATH="${DESTROOT}${MP_PREFIX}/lib ${SRCDIR}/macports1.0 ${SRCDIR}/port1.0 ${SRCDIR}/portlib1.0 ${SRCDIR}/pextlib1.0 ${SRCDIR}/registry2.0 ${SRCDIR}/machista1.0 ${SRCDIR}/mpcommon1.0 ${SRCDIR}/package1.0 ${SRCDIR}/portlist1.0"
+if [ -n "${MACPORTS_TEST_TCLLIBPATH_PREFIX:-}" ]; then
+    export TCLLIBPATH="${MACPORTS_TEST_TCLLIBPATH_PREFIX} ${TEST_TCLLIBPATH}"
+else
+    export TCLLIBPATH="${TEST_TCLLIBPATH}"
+fi
 export MACPORTS_SOURCETREE_DARWINTRACE=${SRCDIR}/darwintracelib1.0
 
 exec "${DESTROOT}@TCLSH@" "$@"

--- a/tests/test.tcl.in
+++ b/tests/test.tcl.in
@@ -6,6 +6,7 @@ set test_suite {
     dependencies-c
     dependencies-d
     dependencies-e
+    deferred-loading
     envvariables
     setuid
     site-tags

--- a/tests/test/deferred-loading/DESCRIPTION
+++ b/tests/test/deferred-loading/DESCRIPTION
@@ -1,0 +1,1 @@
+Verify that portindex only loads parse-time target packages.

--- a/tests/test/deferred-loading/Portfile
+++ b/tests/test/deferred-loading/Portfile
@@ -1,0 +1,11 @@
+PortSystem          1.0
+
+name                deferred-loading-test
+version             1.0
+categories          test
+maintainers         nomaintainer
+description         fixture for deferred-loading integration test
+long_description    ${description}
+platforms           any
+supported_archs     noarch
+license             BSD

--- a/tests/test/deferred-loading/test.tcl
+++ b/tests/test/deferred-loading/test.tcl
@@ -21,18 +21,19 @@ test portindex-deferred-loading-1.0 {
     }
     close $fd
 
-    set had_tcllibpath [info exists env(TCLLIBPATH)]
-    if {$had_tcllibpath} {
-        set saved_tcllibpath $env(TCLLIBPATH)
+    set path_var MACPORTS_TEST_TCLLIBPATH_PREFIX
+    set had_path_prefix [info exists env($path_var)]
+    if {$had_path_prefix} {
+        set saved_path_prefix $env($path_var)
     }
-    set env(TCLLIBPATH) [list $poison_dir]
+    set env($path_var) [list $poison_dir]
     try {
-        port_index
+        port_index -e
     } finally {
-        if {$had_tcllibpath} {
-            set env(TCLLIBPATH) $saved_tcllibpath
+        if {$had_path_prefix} {
+            set env($path_var) $saved_path_prefix
         } else {
-            unset env(TCLLIBPATH)
+            unset env($path_var)
         }
     }
 

--- a/tests/test/deferred-loading/test.tcl
+++ b/tests/test/deferred-loading/test.tcl
@@ -36,7 +36,8 @@ test portindex-deferred-loading-1.0 {
         }
     }
 
-    expr {[file exists ../PortIndex] && [file exists ../PortIndex.quick]}
+    expr {[file exists [file join $test_root ports PortIndex]]
+          && [file exists [file join $test_root ports PortIndex.quick]]}
 } -result 1
 
 cleanupTests

--- a/tests/test/deferred-loading/test.tcl
+++ b/tests/test/deferred-loading/test.tcl
@@ -1,0 +1,36 @@
+package require tcltest 2
+namespace import tcltest::*
+
+set pwd [file dirname [file normalize $argv0]]
+
+source ../library.tcl
+load_variables $pwd
+set_dir
+
+test portindex-deferred-loading-1.0 {
+    portindex must not load a target's runtime package while evaluating Portfiles.
+} -body {
+    global env test_root top_srcdir
+
+    set poison_dir [file join $test_root poisoned-run-packages]
+    file mkdir $poison_dir
+    set fd [open [file join $poison_dir pkgIndex.tcl] w]
+    foreach run_file [glob -tails -directory [file join $top_srcdir src port1.0] *_run.tcl] {
+        set runpkg [file rootname $run_file]
+        puts $fd [list package ifneeded $runpkg 1.0 [list error "Runtime package $runpkg loaded while indexing"]]
+    }
+    close $fd
+
+    global auto_path
+    set saved_auto_path $auto_path
+    set auto_path [linsert $auto_path 0 $poison_dir]
+    try {
+        port_index
+    } finally {
+        set auto_path $saved_auto_path
+    }
+
+    expr {[file exists ../PortIndex] && [file exists ../PortIndex.quick]}
+} -result 1
+
+cleanupTests

--- a/tests/test/deferred-loading/test.tcl
+++ b/tests/test/deferred-loading/test.tcl
@@ -21,13 +21,19 @@ test portindex-deferred-loading-1.0 {
     }
     close $fd
 
-    global auto_path
-    set saved_auto_path $auto_path
-    set auto_path [linsert $auto_path 0 $poison_dir]
+    set had_tcllibpath [info exists env(TCLLIBPATH)]
+    if {$had_tcllibpath} {
+        set saved_tcllibpath $env(TCLLIBPATH)
+    }
+    set env(TCLLIBPATH) [list $poison_dir]
     try {
         port_index
     } finally {
-        set auto_path $saved_auto_path
+        if {$had_tcllibpath} {
+            set env(TCLLIBPATH) $saved_tcllibpath
+        } else {
+            unset env(TCLLIBPATH)
+        }
     }
 
     expr {[file exists ../PortIndex] && [file exists ../PortIndex.quick]}

--- a/tests/test/library.tcl.in
+++ b/tests/test/library.tcl.in
@@ -131,26 +131,28 @@ proc set_dir {} {
 }
 
 # Run portindex
-proc port_index {} {
+proc port_index {args} {
     global cpwd portsrc test_tclsh top_srcdir test_root
 
     # Move up 2 level to run portindex.
     set path [pwd]
-    cd ../..
-    # Avoid warning about ports tree being old
-    foreach portfile [glob -nocomplain */*/Portfile] {
-        file mtime $portfile [clock seconds]
-    }
-
-    without_darwintrace_env {
-        with_portsrc $portsrc {
-            exec -ignorestderr ${test_tclsh} ${top_srcdir}/src/port/portindex.tcl 2>@1
+    try {
+        cd ../..
+        # Avoid warning about ports tree being old
+        foreach portfile [glob -nocomplain */*/Portfile] {
+            file mtime $portfile [clock seconds]
         }
+
+        without_darwintrace_env {
+            with_portsrc $portsrc {
+                exec -ignorestderr ${test_tclsh} ${top_srcdir}/src/port/portindex.tcl {*}$args 2>@1
+            }
+        }
+
+        file copy ${cpwd}/PortIndex ${cpwd}/PortIndex.quick ${test_root}/ports/
+    } finally {
+        cd $path
     }
-
-    file copy ${cpwd}/PortIndex ${cpwd}/PortIndex.quick ${test_root}/ports/
-
-    cd $path
 }
 
 # Executes port clean.


### PR DESCRIPTION
Closes #39.

Adds an integration fixture and standalone `portindex` guard that poison runtime target packages during indexing, force a fresh isolated index, and fail on any parse error. It also exposes `portpatch::patch_main` through a lazy wrapper so PortGroups can customize the patch target without loading `portpatch_run` during indexing.

Validation:

- all 10 GitHub Actions checks pass across macOS 14, macOS 15, macOS 26, and Ubuntu
- clean deferred-loading fixture: 1 passed, 0 failed
- mutation adding `package require portbuild_run 1.0`: 1 failed, proving the poison guard is effective
- `portpatch.test`: 2 passed, 0 failed, 1 root-only test skipped
- full-tree checker with installed stable `portindex`: 40,918 parsed, 40,918 successful
- independent review: PASS at head `56e045fcc`

The synced base separately exposes compatibility defects in the current ports tree when that tree is indexed by the new base itself. Compiler resource safe-parser compatibility is tracked in eejd/macports-ports-dev#30 and is not a blocker for this deferred-loading guard.
