### PR TITLE
Add configurable Rust compiler cache support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@
 ###
 
 Release 2.13.0 (unreleased)
+    - Added an opt-in shared sccache directory for Rust ports, including
+      sandbox access, startup fallback, and reclaim support. (#58)
+
     - Added a --purge option for 'port clean' that quickly and
       unconditionally deletes all files of the chosen type(s).
       (jmr in 22e1abd)

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ Release 2.13.0 (unreleased)
     - Added an opt-in shared sccache directory for Rust ports, including
       sandbox access, startup fallback, and reclaim support. (#58)
 
+    - Confined sccache's object store to a "sccache" subdirectory of
+      rustcache_dir, so that other shared Rust build state kept alongside
+      it is outside sccache's LRU eviction scope. (#58)
+
     - Added a --purge option for 'port clean' that quickly and
       unconditionally deletes all files of the chosen type(s).
       (jmr in 22e1abd)

--- a/doc/macports.conf.5
+++ b/doc/macports.conf.5
@@ -241,6 +241,55 @@ T}
 .sp 1
 .RE
 .PP
+configurerustcache
+.RS 4
+Use sccache (Rust compiler cache)\&. Requires that sccache has been installed\&.
+.TS
+tab(:);
+lt lt.
+T{
+\fBDefault:\fR
+T}:T{
+no
+T}
+.TE
+.sp 1
+.RE
+.PP
+rustcache_dir
+.RS 4
+Location where sccache stores its files
+.TS
+tab(:);
+lt lt.
+T{
+\fBDefault:\fR
+T}:T{
+${portdbpath}/build/\&.rustcache
+T}
+.TE
+.sp 1
+.RE
+.PP
+rustcache_size
+.RS 4
+Maximum size sccache may use\&. Use
+\fIG\fR,
+\fIM\fR, or
+\fIK\fR
+suffix for giga\-, mega\- or kilobytes\&.
+.TS
+tab(:);
+lt lt.
+T{
+\fBDefault:\fR
+T}:T{
+20G
+T}
+.TE
+.sp 1
+.RE
+.PP
 configuredistcc
 .RS 4
 Use distcc (distributed compiler)\&. Requires that distcc has been installed\&.

--- a/doc/macports.conf.5
+++ b/doc/macports.conf.5
@@ -262,7 +262,7 @@ Location of the Rust build cache\&. Holds sccache\*(Aqs object store in
 \fBsccache\fR, the shared vendored crate tree in
 \fBvendor\fR, and the shared linker wrappers in
 \fBcompwrap\fR\&. All of them are cleared by
-\fBport reclaim\fR
+\fBport reclaim\fR\&.
 .TS
 tab(:);
 lt lt.

--- a/doc/macports.conf.5
+++ b/doc/macports.conf.5
@@ -258,7 +258,11 @@ T}
 .PP
 rustcache_dir
 .RS 4
-Location where sccache stores its files
+Location of the Rust build cache\&. Holds sccache\*(Aqs object store in
+\fBsccache\fR, the shared vendored crate tree in
+\fBvendor\fR, and the shared linker wrappers in
+\fBcompwrap\fR\&. All of them are cleared by
+\fBport reclaim\fR
 .TS
 tab(:);
 lt lt.
@@ -279,7 +283,7 @@ Maximum size sccache may use\&. Use
 \fIK\fR
 suffix for giga\-, mega\- or kilobytes\&.
 This setting is read when the sccache server starts\&. Before changing it, substitute the configured cache path and stop the existing server with
-\fBenv SCCACHE_DIR=<rustcache_dir> SCCACHE_SERVER_UDS=<rustcache_dir>/sccache\&.sock sccache \-\-stop\-server\fR\&.
+\fBenv SCCACHE_DIR=<rustcache_dir>/sccache SCCACHE_SERVER_UDS=<rustcache_dir>/sccache\&.sock sccache \-\-stop\-server\fR\&.
 .TS
 tab(:);
 lt lt.

--- a/doc/macports.conf.5
+++ b/doc/macports.conf.5
@@ -229,6 +229,7 @@ Maximum size ccache may use\&. Use
 \fIM\fR, or
 \fIK\fR
 suffix for giga\-, mega\- or kilobytes\&.
+This setting is read when the sccache server starts; stop the server before changing it\&.
 .TS
 tab(:);
 lt lt.

--- a/doc/macports.conf.5
+++ b/doc/macports.conf.5
@@ -229,7 +229,6 @@ Maximum size ccache may use\&. Use
 \fIM\fR, or
 \fIK\fR
 suffix for giga\-, mega\- or kilobytes\&.
-This setting is read when the sccache server starts; stop the server before changing it\&.
 .TS
 tab(:);
 lt lt.
@@ -279,6 +278,8 @@ Maximum size sccache may use\&. Use
 \fIM\fR, or
 \fIK\fR
 suffix for giga\-, mega\- or kilobytes\&.
+This setting is read when the sccache server starts\&. Before changing it, substitute the configured cache path and stop the existing server with
+\fBenv SCCACHE_DIR=<rustcache_dir> SCCACHE_SERVER_UDS=<rustcache_dir>/sccache\&.sock sccache \-\-stop\-server\fR\&.
 .TS
 tab(:);
 lt lt.

--- a/doc/macports.conf.5.txt
+++ b/doc/macports.conf.5.txt
@@ -94,6 +94,19 @@ ccache_size::
     kilobytes.
     *Default:*;; 2G
 
+configurerustcache::
+    Use sccache (Rust compiler cache). Requires that sccache has been installed.
+    *Default:*;; no
+
+rustcache_dir::
+    Location where sccache stores its files.
+    *Default:*;; $\{portdbpath\}/build/.rustcache
+
+rustcache_size::
+    Maximum size sccache may use. Use 'G', 'M', or 'K' suffix for giga-, mega- or
+    kilobytes.
+    *Default:*;; 20G
+
 configuredistcc::
     Use distcc (distributed compiler). Requires that distcc has been installed.
     *Default:*;; no

--- a/doc/macports.conf.5.txt
+++ b/doc/macports.conf.5.txt
@@ -104,8 +104,10 @@ rustcache_dir::
 
 rustcache_size::
     Maximum size sccache may use. Use 'G', 'M', or 'K' suffix for giga-, mega- or
-    kilobytes. This setting is read when the sccache server starts; stop the server
-    before changing it.
+    kilobytes. This setting is read when the sccache server starts. Before changing
+    it, substitute the configured cache path and stop the existing server with
+    `env SCCACHE_DIR=<rustcache_dir> SCCACHE_SERVER_UDS=<rustcache_dir>/sccache.sock
+    sccache --stop-server`.
     *Default:*;; 20G
 
 configuredistcc::

--- a/doc/macports.conf.5.txt
+++ b/doc/macports.conf.5.txt
@@ -104,7 +104,8 @@ rustcache_dir::
 
 rustcache_size::
     Maximum size sccache may use. Use 'G', 'M', or 'K' suffix for giga-, mega- or
-    kilobytes.
+    kilobytes. This setting is read when the sccache server starts; stop the server
+    before changing it.
     *Default:*;; 20G
 
 configuredistcc::

--- a/doc/macports.conf.5.txt
+++ b/doc/macports.conf.5.txt
@@ -99,14 +99,16 @@ configurerustcache::
     *Default:*;; no
 
 rustcache_dir::
-    Location where sccache stores its files.
+    Location of the Rust build cache. Holds sccache's object store in
+    `sccache`, the shared vendored crate tree in `vendor`, and the shared
+    linker wrappers in `compwrap`. All of them are cleared by `port reclaim`.
     *Default:*;; $\{portdbpath\}/build/.rustcache
 
 rustcache_size::
     Maximum size sccache may use. Use 'G', 'M', or 'K' suffix for giga-, mega- or
     kilobytes. This setting is read when the sccache server starts. Before changing
     it, substitute the configured cache path and stop the existing server with
-    `env SCCACHE_DIR=<rustcache_dir> SCCACHE_SERVER_UDS=<rustcache_dir>/sccache.sock
+    `env SCCACHE_DIR=<rustcache_dir>/sccache SCCACHE_SERVER_UDS=<rustcache_dir>/sccache.sock
     sccache --stop-server`.
     *Default:*;; 20G
 

--- a/doc/macports.conf.in
+++ b/doc/macports.conf.in
@@ -111,14 +111,16 @@ variants_conf       	@MPCONFIGDIR_EXPANDED@/variants.conf
 # exist in one of the directories in binpath.
 #configurerustcache  	no
 
-# Directory for sccache's cached compiler output. To prevent sandbox
-# violation errors, the path must contain no symlinks.
+# Directory for the Rust build cache. To prevent sandbox violation errors,
+# the path must contain no symlinks. It holds sccache's cached compiler
+# output in "sccache", the shared vendored crate tree in "vendor", and the
+# shared linker wrappers in "compwrap". "port reclaim" clears all of them.
 #rustcache_dir       	@localstatedir_expanded@/macports/build/.rustcache
 
 # Maximum size of files stored in sccache's cache. Append "G", "M", or
 # "K" for gigabytes, megabytes, or kilobytes. This setting is read when the
 # sccache server starts. Before changing it, stop the existing server with:
-# env SCCACHE_DIR=<rustcache_dir> SCCACHE_SERVER_UDS=<rustcache_dir>/sccache.sock sccache --stop-server
+# env SCCACHE_DIR=<rustcache_dir>/sccache SCCACHE_SERVER_UDS=<rustcache_dir>/sccache.sock sccache --stop-server
 #rustcache_size      	20G
 
 # Use distcc, a distributed compiler for C, C++, Objective-C, and

--- a/doc/macports.conf.in
+++ b/doc/macports.conf.in
@@ -117,7 +117,8 @@ variants_conf       	@MPCONFIGDIR_EXPANDED@/variants.conf
 
 # Maximum size of files stored in sccache's cache. Append "G", "M", or
 # "K" for gigabytes, megabytes, or kilobytes. This setting is read when the
-# sccache server starts; stop the server before changing it.
+# sccache server starts. Before changing it, stop the existing server with:
+# env SCCACHE_DIR=<rustcache_dir> SCCACHE_SERVER_UDS=<rustcache_dir>/sccache.sock sccache --stop-server
 #rustcache_size      	20G
 
 # Use distcc, a distributed compiler for C, C++, Objective-C, and

--- a/doc/macports.conf.in
+++ b/doc/macports.conf.in
@@ -107,6 +107,18 @@ variants_conf       	@MPCONFIGDIR_EXPANDED@/variants.conf
 # "K" for gigabytes, megabytes, or kilobytes.
 #ccache_size         	2G
 
+# Use sccache to cache Rust compiler output. The "sccache" executable must
+# exist in one of the directories in binpath.
+#configurerustcache  	no
+
+# Directory for sccache's cached compiler output. To prevent sandbox
+# violation errors, the path must contain no symlinks.
+#rustcache_dir       	@localstatedir_expanded@/macports/build/.rustcache
+
+# Maximum size of files stored in sccache's cache. Append "G", "M", or
+# "K" for gigabytes, megabytes, or kilobytes.
+#rustcache_size      	20G
+
 # Use distcc, a distributed compiler for C, C++, Objective-C, and
 # Objective-C++. (See http://distcc.org.) The "distcc" executable must
 # exist in one of the directories in binpath.

--- a/doc/macports.conf.in
+++ b/doc/macports.conf.in
@@ -116,7 +116,8 @@ variants_conf       	@MPCONFIGDIR_EXPANDED@/variants.conf
 #rustcache_dir       	@localstatedir_expanded@/macports/build/.rustcache
 
 # Maximum size of files stored in sccache's cache. Append "G", "M", or
-# "K" for gigabytes, megabytes, or kilobytes.
+# "K" for gigabytes, megabytes, or kilobytes. This setting is read when the
+# sccache server starts; stop the server before changing it.
 #rustcache_size      	20G
 
 # Use distcc, a distributed compiler for C, C++, Objective-C, and

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -49,7 +49,7 @@ namespace eval macports {
         rsync_server rsync_options rsync_dir \
         startupitem_autostart startupitem_type startupitem_install \
         place_worksymlink xcodeversion xcodebuildcmd xcodecltversion xcode_license_unaccepted \
-        configureccache ccache_size configuredistcc configurepipe buildnicevalue buildmakejobs \
+        configureccache ccache_size configurerustcache rustcache_size configuredistcc configurepipe buildnicevalue buildmakejobs \
         universal_archs build_arch macosx_sdk_version macosx_deployment_target \
         macportsuser proxy_override_env proxy_http proxy_https proxy_ftp proxy_rsync proxy_skip \
         master_site_local patch_site_local archive_site_local fetch_credentials fetch_threads \
@@ -59,7 +59,7 @@ namespace eval macports {
             dict set bootstrap_options $opt {}
     }
     # Config file options that are a filesystem path and should be fully resolved
-    foreach opt [list applications_dir archive_sites_conf ccache_dir developer_dir \
+    foreach opt [list applications_dir archive_sites_conf ccache_dir rustcache_dir developer_dir \
                       frameworks_dir packagemaker_path portdbpath prefix pubkeys_conf \
                       sources_conf variants_conf] {
         dict set bootstrap_options $opt is_path 1
@@ -74,7 +74,7 @@ namespace eval macports {
         portautoclean portimage_mode porttrace keeplogs portverbose destroot_umask \
         rsync_server rsync_options rsync_dir startupitem_autostart startupitem_type startupitem_install \
         place_worksymlink macportsuser sudo_user \
-        configureccache ccache_dir ccache_size configuredistcc configurepipe buildnicevalue buildmakejobs \
+        configureccache ccache_dir ccache_size configurerustcache rustcache_dir rustcache_size configuredistcc configurepipe buildnicevalue buildmakejobs \
         applications_dir applications_dir_frozen current_phase frameworks_dir frameworks_dir_frozen \
         developer_dir universal_archs build_arch os_arch os_endian os_version os_major os_minor \
         os_platform os_subplatform macos_version macos_version_major macosx_version macosx_sdk_version \
@@ -1065,6 +1065,9 @@ proc mportinit {{up_ui_options {}} {up_options {}} {up_variations {}}} {
         macports::configureccache \
         macports::ccache_dir \
         macports::ccache_size \
+        macports::configurerustcache \
+        macports::rustcache_dir \
+        macports::rustcache_size \
         macports::configuredistcc \
         macports::configurepipe \
         macports::buildnicevalue \
@@ -1646,6 +1649,15 @@ match macports.conf.default."
     if {![info exists ccache_size]} {
         set ccache_size 2G
     }
+    if {![info exists configurerustcache]} {
+        set configurerustcache no
+    }
+    if {![info exists rustcache_dir]} {
+        set rustcache_dir [file join $portdbpath build .rustcache]
+    }
+    if {![info exists rustcache_size]} {
+        set rustcache_size 20G
+    }
     if {![info exists configuredistcc]} {
         set configuredistcc no
     }
@@ -1981,6 +1993,11 @@ match macports.conf.default."
 
     # add ccache to environment
     set env(CCACHE_DIR) $ccache_dir
+
+    # Add the Rust compiler cache settings to the process environment.
+    set env(SCCACHE_DIR) $rustcache_dir
+    set env(SCCACHE_CACHE_SIZE) $rustcache_size
+    set env(SCCACHE_SERVER_UDS) [file join $rustcache_dir sccache.sock]
 
     # load caches on demand
     trace add variable macports::compiler_version_cache read macports::load_compiler_version_cache

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -1995,7 +1995,10 @@ match macports.conf.default."
     set env(CCACHE_DIR) $ccache_dir
 
     # Add the Rust compiler cache settings to the process environment.
-    set env(SCCACHE_DIR) $rustcache_dir
+    # SCCACHE_DIR is a subdirectory of rustcache_dir, not rustcache_dir itself:
+    # sccache's LRU evicts everything it finds under SCCACHE_DIR, and the shared
+    # vendor tree and linker wrappers are siblings of the object store.
+    set env(SCCACHE_DIR) [file join $rustcache_dir sccache]
     set env(SCCACHE_CACHE_SIZE) $rustcache_size
     set env(SCCACHE_SERVER_UDS) [file join $rustcache_dir sccache.sock]
 

--- a/src/macports1.0/reclaim.tcl
+++ b/src/macports1.0/reclaim.tcl
@@ -216,7 +216,7 @@ namespace eval reclaim {
             if {[file exists ${rustcache_socket}]} {
                 if {[catch {
                         exec env \
-                            SCCACHE_DIR=${rustcache_dir} \
+                            SCCACHE_DIR=[file join ${rustcache_dir} sccache] \
                             SCCACHE_SERVER_UDS=${rustcache_socket} \
                             [file join ${prefix} bin sccache] --stop-server \
                             >/dev/null 2>@1

--- a/src/macports1.0/reclaim.tcl
+++ b/src/macports1.0/reclaim.tcl
@@ -77,6 +77,7 @@ namespace eval reclaim {
         remove_distfiles
         remove_builds
         remove_ccache
+        remove_rustcache
         remove_snapshots
 
         if {![macports::global_option_isset ports_dryrun]} {
@@ -175,6 +176,44 @@ namespace eval reclaim {
             ui_info [msgcat::mc "Deleting everything under %s" $ccache_dir]
             macports_try -pass_signal {
                 file delete -force -- {*}$ccachedirs
+            } on error {eMessage} {
+                ui_debug "$::errorInfo"
+                ui_error "$eMessage"
+            }
+        }
+    }
+
+    proc remove_rustcache {} {
+        global macports::rustcache_dir macports::ui_prefix macports::ui_options
+
+        if {![file exists ${rustcache_dir}]} {
+            ui_info [msgcat::mc "Skipping deletion of Rust cache directory: %s does not exist." $rustcache_dir]
+            return
+        }
+
+        ui_msg "$ui_prefix Rust cache location: ${rustcache_dir}"
+
+        if {[macports::global_option_isset ports_dryrun]} {
+            ui_msg "Deleting... (dry run)"
+            ui_info [msgcat::mc "Skipping deletion of everything under %s (dry run)" $rustcache_dir]
+            return
+        }
+
+        set rustcachedirs [glob -nocomplain -directory $rustcache_dir *]
+        if {[llength $rustcachedirs] == 0} {
+            ui_info [msgcat::mc "No Rust cache directories to delete"]
+            return
+        }
+
+        set retval 0
+        if {[info exists ui_options(questions_yesno)]} {
+            set retval [$ui_options(questions_yesno) "" "" "" "y" 0 "Would you like to delete everything under the Rust cache directory?"]
+        }
+
+        if {${retval} == 0} {
+            ui_info [msgcat::mc "Deleting everything under %s" $rustcache_dir]
+            macports_try -pass_signal {
+                file delete -force -- {*}$rustcachedirs
             } on error {eMessage} {
                 ui_debug "$::errorInfo"
                 ui_error "$eMessage"

--- a/src/macports1.0/reclaim.tcl
+++ b/src/macports1.0/reclaim.tcl
@@ -184,7 +184,7 @@ namespace eval reclaim {
     }
 
     proc remove_rustcache {} {
-        global macports::rustcache_dir macports::ui_prefix macports::ui_options
+        global macports::prefix macports::rustcache_dir macports::ui_prefix macports::ui_options
 
         if {![file exists ${rustcache_dir}]} {
             ui_info [msgcat::mc "Skipping deletion of Rust cache directory: %s does not exist." $rustcache_dir]
@@ -212,6 +212,18 @@ namespace eval reclaim {
 
         if {${retval} == 0} {
             ui_info [msgcat::mc "Deleting everything under %s" $rustcache_dir]
+            set rustcache_socket [file join ${rustcache_dir} sccache.sock]
+            if {[file exists ${rustcache_socket}]} {
+                if {[catch {
+                        exec env \
+                            SCCACHE_DIR=${rustcache_dir} \
+                            SCCACHE_SERVER_UDS=${rustcache_socket} \
+                            [file join ${prefix} bin sccache] --stop-server \
+                            >/dev/null 2>@1
+                    } result]} {
+                    ui_debug "Could not stop the Rust cache server before reclaim: $result"
+                }
+            }
             macports_try -pass_signal {
                 file delete -force -- {*}$rustcachedirs
             } on error {eMessage} {

--- a/src/macports1.0/tests/macports.test
+++ b/src/macports1.0/tests/macports.test
@@ -12,6 +12,45 @@ source $macports::autoconf::top_srcdir/src/macports1.0/tests/test_setup.tcl
 package require Thread
 
 
+test rustcache_defaults {
+    Rust compiler cache options have safe defaults and bootstrap metadata.
+} -body {
+    list \
+        $macports::configurerustcache \
+        $macports::rustcache_dir \
+        $macports::rustcache_size \
+        [dict exists $macports::bootstrap_options configurerustcache] \
+        [dict get $macports::bootstrap_options rustcache_dir is_path] \
+        [dict exists $macports::bootstrap_options rustcache_size] \
+        $::env(SCCACHE_DIR) \
+        $::env(SCCACHE_CACHE_SIZE) \
+        $::env(SCCACHE_SERVER_UDS)
+} -result [list \
+    no \
+    [file join $pwd tmpdir var macports build .rustcache] \
+    20G \
+    1 \
+    1 \
+    1 \
+    [file join $pwd tmpdir var macports build .rustcache] \
+    20G \
+    [file join $pwd tmpdir var macports build .rustcache sccache.sock]]
+
+
+test rustcache_cli_override {
+    A per-invocation configurerustcache option overrides the global default in the Portfile interpreter.
+} -setup {
+    set mport [mportopen file://${pwd} [dict create configurerustcache yes] {} yes]
+    set workername [ditem_key $mport workername]
+} -body {
+    list \
+        [$workername eval [list set configurerustcache]] \
+        [$workername eval [list set configure.rustcache]]
+} -cleanup {
+    mportclose $mport
+} -result {yes yes}
+
+
 test mportclose {
     Mport close unit test.
 } -setup {

--- a/src/macports1.0/tests/macports.test
+++ b/src/macports1.0/tests/macports.test
@@ -32,7 +32,7 @@ test rustcache_defaults {
     1 \
     1 \
     1 \
-    [file join $pwd tmpdir var macports build .rustcache] \
+    [file join $pwd tmpdir var macports build .rustcache sccache] \
     20G \
     [file join $pwd tmpdir var macports build .rustcache sccache.sock]]
 

--- a/src/macports1.0/tests/reclaim.test
+++ b/src/macports1.0/tests/reclaim.test
@@ -63,6 +63,37 @@ test remove_rustcache {
     set macports::rustcache_dir $saved_rustcache_dir
 }
 
+test remove_rustcache_stops_server {
+    Test that reclaim stops the server associated with the cache socket before deleting it.
+} -setup {
+    set saved_rustcache_dir ${macports::rustcache_dir}
+    set macports::rustcache_dir [makeDirectory "reclaim_test_rustcache_server"]
+    set socket [makeFile "socket placeholder" "sccache.sock" ${macports::rustcache_dir}]
+    set stop_command {}
+    set socket_existed_at_stop no
+    rename exec exec_real
+    proc exec {args} {
+        set ::stop_command $args
+        set ::socket_existed_at_stop [file exists $::socket]
+        return {}
+    }
+} -body {
+    reclaim::remove_rustcache
+    set expected_stop_command [list env \
+        SCCACHE_DIR=${macports::rustcache_dir} \
+        SCCACHE_SERVER_UDS=[file join ${macports::rustcache_dir} sccache.sock] \
+        [file join ${macports::prefix} bin sccache] --stop-server \
+        >/dev/null 2>@1]
+    list \
+        $socket_existed_at_stop \
+        [expr {$stop_command eq $expected_stop_command}] \
+        [file exists $socket]
+} -result {1 1 0} -cleanup {
+    rename exec {}
+    rename exec_real exec
+    set macports::rustcache_dir $saved_rustcache_dir
+}
+
 test remove_rustcache_dryrun {
     Test that reclaim dry-run preserves Rust cache contents.
 } -setup {

--- a/src/macports1.0/tests/reclaim.test
+++ b/src/macports1.0/tests/reclaim.test
@@ -50,6 +50,34 @@ test remove_distfiles_keeps_turd_file {
     return [file exists $turdfile]
 } -result 1 -cleanup $cleanup_testdir
 
+test remove_rustcache {
+    Test that reclaim removes Rust cache contents but preserves the configured cache directory.
+} -setup {
+    set saved_rustcache_dir ${macports::rustcache_dir}
+    set macports::rustcache_dir [makeDirectory "reclaim_test_rustcache"]
+    set cachefile [makeFile "cached object" "object" ${macports::rustcache_dir}]
+} -body {
+    reclaim::remove_rustcache
+    list [file exists ${macports::rustcache_dir}] [file exists $cachefile]
+} -result {1 0} -cleanup {
+    set macports::rustcache_dir $saved_rustcache_dir
+}
+
+test remove_rustcache_dryrun {
+    Test that reclaim dry-run preserves Rust cache contents.
+} -setup {
+    set saved_rustcache_dir ${macports::rustcache_dir}
+    set macports::rustcache_dir [makeDirectory "reclaim_test_rustcache_dryrun"]
+    set cachefile [makeFile "cached object" "object" ${macports::rustcache_dir}]
+    set macports::global_options(ports_dryrun) yes
+} -body {
+    reclaim::remove_rustcache
+    list [file exists ${macports::rustcache_dir}] [file exists $cachefile]
+} -result {1 1} -cleanup {
+    unset -nocomplain macports::global_options(ports_dryrun)
+    set macports::rustcache_dir $saved_rustcache_dir
+}
+
 test update_last_run {
     Tests for last_reclaim file being updated.
 } -setup $setup_testdir -body {

--- a/src/macports1.0/tests/reclaim.test
+++ b/src/macports1.0/tests/reclaim.test
@@ -80,7 +80,7 @@ test remove_rustcache_stops_server {
 } -body {
     reclaim::remove_rustcache
     set expected_stop_command [list env \
-        SCCACHE_DIR=${macports::rustcache_dir} \
+        SCCACHE_DIR=[file join ${macports::rustcache_dir} sccache] \
         SCCACHE_SERVER_UDS=[file join ${macports::rustcache_dir} sccache.sock] \
         [file join ${macports::prefix} bin sccache] --stop-server \
         >/dev/null 2>@1]

--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -322,11 +322,12 @@ default configure.universal_cppflags    {}
 default configure.universal_ldflags     {[portconfigure::configure_get_universal_archflags]}
 
 # Select a distinct compiler (C, C preprocessor, C++)
-options configure.ccache configure.distcc configure.pipe configure.cc \
+options configure.ccache configure.rustcache configure.distcc configure.pipe configure.cc \
         configure.cpp configure.objc configure.f77 \
         configure.f90 configure.fc configure.javac configure.compiler \
         compiler.blacklist compiler.whitelist compiler.fallback
 default configure.ccache        {${configureccache}}
+default configure.rustcache     {${configurerustcache}}
 default configure.distcc        {${configuredistcc}}
 default configure.pipe          {${configurepipe}}
 foreach _portconfigure_tool {cc objc cpp f77 f90 fc javac} {

--- a/src/port1.0/portconfigure_run.tcl
+++ b/src/port1.0/portconfigure_run.tcl
@@ -8,6 +8,26 @@ package require portprogress 1.0
 
 namespace eval portconfigure {
 
+proc disable_rustcache_environment {} {
+    global prefix rustcache_dir rustcache_size
+
+    set cache_env [list \
+        RUSTC_WRAPPER=${prefix}/bin/sccache \
+        SCCACHE_CACHE_SIZE=${rustcache_size} \
+        SCCACHE_DIR=${rustcache_dir} \
+        SCCACHE_SERVER_UDS=[file join ${rustcache_dir} sccache.sock] \
+        CARGO_INCREMENTAL=0]
+    foreach phase {configure build destroot} {
+        upvar #0 ${phase}.env phase_env
+        foreach entry ${cache_env} {
+            set index [lsearch -exact ${phase_env} ${entry}]
+            if {${index} >= 0} {
+                lpop phase_env ${index}
+            }
+        }
+    }
+}
+
 proc configure_start {args} {
     global UI_PREFIX subport configure.compiler compiler.fallback configure.ccache configure.rustcache
 
@@ -87,6 +107,7 @@ proc configure_start {args} {
             } result]} {
             ui_warn "rustcache_dir ${rustcache_dir} could not be created; disabling Rust cache: $result"
             set configure.rustcache no
+            disable_rustcache_environment
         }
         dropPrivileges
 
@@ -109,6 +130,7 @@ proc configure_start {args} {
                 } result]} {
                 ui_warn "rustcache_dir ${rustcache_dir} could not be initialized; disabling Rust cache: $result"
                 set configure.rustcache no
+                disable_rustcache_environment
             }
         }
     }

--- a/src/port1.0/portconfigure_run.tcl
+++ b/src/port1.0/portconfigure_run.tcl
@@ -92,7 +92,20 @@ proc configure_start {args} {
 
         if {${configure.rustcache}} {
             if {[catch {
-                    exec sccache --start-server >/dev/null
+                    set had_tmpdir [info exists ::env(TMPDIR)]
+                    if {${had_tmpdir}} {
+                        set saved_tmpdir $::env(TMPDIR)
+                    }
+                    set ::env(TMPDIR) ${rustcache_dir}
+                    try {
+                        exec sccache --start-server >/dev/null
+                    } finally {
+                        if {${had_tmpdir}} {
+                            set ::env(TMPDIR) ${saved_tmpdir}
+                        } else {
+                            unset ::env(TMPDIR)
+                        }
+                    }
                 } result]} {
                 ui_warn "rustcache_dir ${rustcache_dir} could not be initialized; disabling Rust cache: $result"
                 set configure.rustcache no

--- a/src/port1.0/portconfigure_run.tcl
+++ b/src/port1.0/portconfigure_run.tcl
@@ -9,7 +9,7 @@ package require portprogress 1.0
 namespace eval portconfigure {
 
 proc configure_start {args} {
-    global UI_PREFIX subport configure.compiler compiler.fallback configure.ccache
+    global UI_PREFIX subport configure.compiler compiler.fallback configure.ccache configure.rustcache
 
     ui_notice "$UI_PREFIX [format [msgcat::mc "Configuring %s"] $subport]"
 
@@ -74,6 +74,28 @@ proc configure_start {args} {
             } result]} {
                 ui_warn "ccache_dir ${ccache_dir} could not be initialized; disabling ccache: $result"
                 set configure.ccache no
+            }
+        }
+    }
+
+    if {${configure.rustcache} && [namespace exists ::rust]} {
+        global rustcache_dir macportsuser
+        elevateToRoot "configure rust cache"
+        if {[catch {
+                file mkdir ${rustcache_dir}
+                file attributes ${rustcache_dir} -owner ${macportsuser} -permissions 0755
+            } result]} {
+            ui_warn "rustcache_dir ${rustcache_dir} could not be created; disabling Rust cache: $result"
+            set configure.rustcache no
+        }
+        dropPrivileges
+
+        if {${configure.rustcache}} {
+            if {[catch {
+                    exec sccache --start-server >/dev/null
+                } result]} {
+                ui_warn "rustcache_dir ${rustcache_dir} could not be initialized; disabling Rust cache: $result"
+                set configure.rustcache no
             }
         }
     }

--- a/src/port1.0/portconfigure_run.tcl
+++ b/src/port1.0/portconfigure_run.tcl
@@ -14,7 +14,7 @@ proc disable_rustcache_environment {} {
     set cache_env [list \
         RUSTC_WRAPPER=${prefix}/bin/sccache \
         SCCACHE_CACHE_SIZE=${rustcache_size} \
-        SCCACHE_DIR=${rustcache_dir} \
+        SCCACHE_DIR=[file join ${rustcache_dir} sccache] \
         SCCACHE_SERVER_UDS=[file join ${rustcache_dir} sccache.sock] \
         CARGO_INCREMENTAL=0]
     foreach phase {configure build destroot} {
@@ -101,9 +101,14 @@ proc configure_start {args} {
     if {${configure.rustcache} && [namespace exists ::rust]} {
         global rustcache_dir macportsuser
         elevateToRoot "configure rust cache"
+        # The sccache object store is deliberately confined to a subdirectory:
+        # sccache's LRU walks its whole SCCACHE_DIR and evicts anything it finds
+        # there under size pressure, so rustcache_dir itself must not be it --
+        # the shared vendor tree and linker wrappers live alongside it.
         if {[catch {
-                file mkdir ${rustcache_dir}
+                file mkdir [file join ${rustcache_dir} sccache]
                 file attributes ${rustcache_dir} -owner ${macportsuser} -permissions 0755
+                file attributes [file join ${rustcache_dir} sccache] -owner ${macportsuser} -permissions 0755
             } result]} {
             ui_warn "rustcache_dir ${rustcache_dir} could not be created; disabling Rust cache: $result"
             set configure.rustcache no

--- a/src/port1.0/portsandbox.tcl
+++ b/src/port1.0/portsandbox.tcl
@@ -44,7 +44,7 @@ default portsandbox_profile {}
 # sandbox-exec -p '(version 1) (allow default) (deny file-write*) (allow file-write* <filter>)' some-command
 proc portsandbox::set_profile {target} {
     global os.major portsandbox_profile workpath worksrcpath distpath \
-        package.destpath configure.ccache ccache_dir portdbpath \
+        package.destpath configure.ccache ccache_dir configure.rustcache rustcache_dir portdbpath \
         sandbox_network configure.distcc porttrace prefix_frozen \
         build.type
 
@@ -88,6 +88,9 @@ proc portsandbox::set_profile {target} {
     }
     if {${configure.ccache}} {
         lappend allow_dirs $ccache_dir
+    }
+    if {${configure.rustcache} && [namespace exists ::rust]} {
+        lappend allow_dirs $rustcache_dir
     }
     if {${build.type} eq "xcode"} {
         # whitelist directories used by Xcode tools
@@ -163,6 +166,9 @@ proc portsandbox::set_profile {target} {
                     # allow accessing the darwintrace fifo in trace mode
                     set template [string trimright ${::porttrace::fifo_mktemp_template} "X"]
                     append portsandbox_profile " (allow network-outbound (to unix-socket) (regex #\"^${template}\"))"
+                }
+                if {${configure.rustcache} && [namespace exists ::rust]} {
+                    append portsandbox_profile " (allow network-outbound (to unix-socket) (literal \"[file join $rustcache_dir sccache.sock]\"))"
                 }
             }
         }

--- a/src/port1.0/porttrace.tcl
+++ b/src/port1.0/porttrace.tcl
@@ -269,6 +269,11 @@ namespace eval porttrace {
             }
         }
 
+        if {[option configure.rustcache] && [namespace exists ::rust]} {
+            global rustcache_dir
+            allow trace_sandbox $rustcache_dir
+        }
+
         # Grant access to the directory we use to mirror binaries under SIP
         if {[info exists ::env(DARWINTRACE_SIP_WORKAROUND_PATH)]} {
             allow trace_sandbox $::env(DARWINTRACE_SIP_WORKAROUND_PATH)

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -1114,6 +1114,10 @@ proc target_run {ditem} {
                     if {[option configure.ccache] && [file exists ${prefix_frozen}/bin/ccache]} {
                         lappend depends path:bin/ccache:ccache
                     }
+                    if {[option configure.rustcache] && [namespace exists ::rust]
+                        && [file exists ${prefix_frozen}/bin/sccache]} {
+                        lappend depends path:bin/sccache:sccache
+                    }
 
                     # Recursively collect all dependencies from registry for tracing
                     set depset [dict create]

--- a/src/port1.0/tests/portrustcache.test
+++ b/src/port1.0/tests/portrustcache.test
@@ -72,6 +72,60 @@ test rustcache_start_server {
 } -result {yes 1 {sccache --start-server >/dev/null} 1 1}
 
 
+test rustcache_start_failure_disables_wrapper {
+    A failed sccache start removes the cache environment so the Rust build can continue uncached.
+} -setup {
+    namespace eval rust {}
+    set UI_PREFIX {}
+    set subport rustcache-test
+    set prefix /opt/local
+    set configure.compiler clang
+    set compiler.fallback {clang}
+    set configure.ccache no
+    set configure.rustcache yes
+    set rustcache_dir [makeDirectory rustcache_start_failure]
+    set rustcache_size 20G
+    set macportsuser [file attributes $rustcache_dir -owner]
+    set portconfigure::no_default_compiler_allowed no
+    set cache_env [list \
+        RUSTC_WRAPPER=${prefix}/bin/sccache \
+        SCCACHE_CACHE_SIZE=${rustcache_size} \
+        SCCACHE_DIR=${rustcache_dir} \
+        SCCACHE_SERVER_UDS=[file join ${rustcache_dir} sccache.sock] \
+        CARGO_INCREMENTAL=0]
+    foreach phase {configure build destroot} {
+        set ${phase}.env [concat KEEP_ME=yes ${cache_env}]
+    }
+    foreach command {elevateToRoot dropPrivileges} {
+        if {[llength [info commands $command]]} {
+            rename $command ${command}_saved
+        }
+        proc $command {args} {}
+    }
+    rename exec exec_real
+    proc exec {args} {
+        return -code error "sccache unavailable"
+    }
+} -body {
+    portconfigure::configure_start
+    list \
+        ${configure.rustcache} \
+        ${configure.env} \
+        ${build.env} \
+        ${destroot.env}
+} -cleanup {
+    rename exec {}
+    rename exec_real exec
+    foreach command {elevateToRoot dropPrivileges} {
+        rename $command {}
+        if {[llength [info commands ${command}_saved]]} {
+            rename ${command}_saved $command
+        }
+    }
+    namespace delete rust
+} -result {no KEEP_ME=yes KEEP_ME=yes KEEP_ME=yes}
+
+
 test rustcache_sandbox_profile {
     Rust cache builds can write the cache and connect to the configured Unix socket while network sandboxing is active.
 } -setup {

--- a/src/port1.0/tests/portrustcache.test
+++ b/src/port1.0/tests/portrustcache.test
@@ -1,0 +1,96 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+package require tcltest 2
+namespace import tcltest::*
+::tcltest::configure {*}$::argv
+
+set pwd [file dirname [file normalize $argv0]]
+
+source ../port_test_autoconf.tcl
+source ../port_autoconf.tcl
+source $macports::autoconf::top_srcdir/src/macports1.0/tests/test_setup.tcl
+
+macports_worker_init
+namespace eval port {
+    proc register_callback {args} {}
+    proc run_callbacks {args} {}
+}
+
+package require portutil 1.0
+package require portconfigure 1.0
+package require portconfigure_run 1.0
+package require portsandbox 1.0
+
+
+test rustcache_start_server {
+    Configuring a Rust port initializes its cache directory and starts the matching sccache server.
+} -setup {
+    namespace eval rust {}
+    set UI_PREFIX {}
+    set subport rustcache-test
+    set configure.compiler clang
+    set compiler.fallback {clang}
+    set configure.ccache no
+    set configure.rustcache yes
+    set rustcache_dir [makeDirectory rustcache_start_server]
+    set macportsuser [file attributes $rustcache_dir -owner]
+    set portconfigure::no_default_compiler_allowed no
+    set sccache_command {}
+    foreach command {elevateToRoot dropPrivileges} {
+        if {[llength [info commands $command]]} {
+            rename $command ${command}_saved
+        }
+        proc $command {args} {}
+    }
+    rename exec exec_real
+    proc exec {args} {
+        set ::sccache_command $args
+        return {}
+    }
+} -body {
+    portconfigure::configure_start
+    list ${configure.rustcache} [file isdirectory $rustcache_dir] $sccache_command
+} -cleanup {
+    rename exec {}
+    rename exec_real exec
+    foreach command {elevateToRoot dropPrivileges} {
+        rename $command {}
+        if {[llength [info commands ${command}_saved]]} {
+            rename ${command}_saved $command
+        }
+    }
+    namespace delete rust
+} -result {yes 1 {sccache --start-server >/dev/null}}
+
+
+test rustcache_sandbox_profile {
+    Rust cache builds can write the cache and connect to the configured Unix socket while network sandboxing is active.
+} -setup {
+    namespace eval rust {}
+    set sandbox_root [makeDirectory rustcache_sandbox_profile]
+    set os.major 20
+    set workpath [makeDirectory work $sandbox_root]
+    set worksrcpath [makeDirectory src $sandbox_root]
+    set distpath [makeDirectory dist $sandbox_root]
+    set package.destpath [makeDirectory pkg $sandbox_root]
+    set configure.ccache no
+    set ccache_dir [makeDirectory ccache $sandbox_root]
+    set configure.rustcache yes
+    set rustcache_dir [makeDirectory rustcache $sandbox_root]
+    set portdbpath [makeDirectory portdb $sandbox_root]
+    set sandbox_network yes
+    set configure.distcc no
+    set porttrace no
+    set prefix_frozen [makeDirectory prefix $sandbox_root]
+    set build.type default
+    set portsandbox_profile {}
+} -body {
+    portsandbox::set_profile build
+    list \
+        [expr {[string first "subpath \"${rustcache_dir}\"" $portsandbox_profile] >= 0}] \
+        [expr {[string first "literal \"[file join $rustcache_dir sccache.sock]\"" $portsandbox_profile] >= 0}]
+} -cleanup {
+    namespace delete rust
+} -result {1 1}
+
+cleanupTests

--- a/src/port1.0/tests/portrustcache.test
+++ b/src/port1.0/tests/portrustcache.test
@@ -56,6 +56,7 @@ test rustcache_start_server {
     list \
         ${configure.rustcache} \
         [file isdirectory $rustcache_dir] \
+        [file isdirectory [file join $rustcache_dir sccache]] \
         $sccache_command \
         [expr {$sccache_tmpdir eq $rustcache_dir}] \
         [expr {$env(TMPDIR) eq $original_tmpdir}]
@@ -69,7 +70,7 @@ test rustcache_start_server {
         }
     }
     namespace delete rust
-} -result {yes 1 {sccache --start-server >/dev/null} 1 1}
+} -result {yes 1 1 {sccache --start-server >/dev/null} 1 1}
 
 
 test rustcache_start_failure_disables_wrapper {
@@ -90,7 +91,7 @@ test rustcache_start_failure_disables_wrapper {
     set cache_env [list \
         RUSTC_WRAPPER=${prefix}/bin/sccache \
         SCCACHE_CACHE_SIZE=${rustcache_size} \
-        SCCACHE_DIR=${rustcache_dir} \
+        SCCACHE_DIR=[file join ${rustcache_dir} sccache] \
         SCCACHE_SERVER_UDS=[file join ${rustcache_dir} sccache.sock] \
         CARGO_INCREMENTAL=0]
     foreach phase {configure build destroot} {
@@ -155,5 +156,55 @@ test rustcache_sandbox_profile {
 } -cleanup {
     namespace delete rust
 } -result {1 1}
+
+test rustcache_store_is_confined_to_a_subdirectory {
+    The sccache object store must be a strict subdirectory of rustcache_dir, so that the
+    shared vendor tree and linker wrappers stored alongside it are outside sccache's LRU
+    scope. sccache walks and evicts everything below SCCACHE_DIR.
+} -setup {
+    namespace eval rust {}
+    set UI_PREFIX {}
+    set subport rustcache-test
+    set prefix /opt/local
+    set configure.compiler clang
+    set compiler.fallback {clang}
+    set configure.ccache no
+    set configure.rustcache yes
+    set rustcache_dir [makeDirectory rustcache_store_confinement]
+    set rustcache_size 20G
+    set macportsuser [file attributes $rustcache_dir -owner]
+    set env(TMPDIR) [makeDirectory rustcache_store_confinement_tmp]
+    set portconfigure::no_default_compiler_allowed no
+    # The sibling directories the PortGroups place next to the object store.
+    set vendor_dir [makeDirectory vendor $rustcache_dir]
+    set compwrap_dir [makeDirectory compwrap $rustcache_dir]
+    foreach command {elevateToRoot dropPrivileges} {
+        if {[llength [info commands $command]]} {
+            rename $command ${command}_saved
+        }
+        proc $command {args} {}
+    }
+    rename exec exec_real
+    proc exec {args} {return {}}
+} -body {
+    portconfigure::configure_start
+    set store [file join $rustcache_dir sccache]
+    list \
+        [expr {$store ne $rustcache_dir}] \
+        [file isdirectory $store] \
+        [expr {[string first "${store}/" "${vendor_dir}/"] == 0}] \
+        [expr {[string first "${store}/" "${compwrap_dir}/"] == 0}]
+} -cleanup {
+    rename exec {}
+    rename exec_real exec
+    foreach command {elevateToRoot dropPrivileges} {
+        rename $command {}
+        if {[llength [info commands ${command}_saved]]} {
+            rename ${command}_saved $command
+        }
+    }
+    namespace delete rust
+} -result {1 1 0 0}
+
 
 cleanupTests

--- a/src/port1.0/tests/portrustcache.test
+++ b/src/port1.0/tests/portrustcache.test
@@ -34,8 +34,11 @@ test rustcache_start_server {
     set configure.rustcache yes
     set rustcache_dir [makeDirectory rustcache_start_server]
     set macportsuser [file attributes $rustcache_dir -owner]
+    set original_tmpdir [makeDirectory original_tmpdir]
+    set env(TMPDIR) $original_tmpdir
     set portconfigure::no_default_compiler_allowed no
     set sccache_command {}
+    set sccache_tmpdir {}
     foreach command {elevateToRoot dropPrivileges} {
         if {[llength [info commands $command]]} {
             rename $command ${command}_saved
@@ -45,11 +48,17 @@ test rustcache_start_server {
     rename exec exec_real
     proc exec {args} {
         set ::sccache_command $args
+        set ::sccache_tmpdir $::env(TMPDIR)
         return {}
     }
 } -body {
     portconfigure::configure_start
-    list ${configure.rustcache} [file isdirectory $rustcache_dir] $sccache_command
+    list \
+        ${configure.rustcache} \
+        [file isdirectory $rustcache_dir] \
+        $sccache_command \
+        [expr {$sccache_tmpdir eq $rustcache_dir}] \
+        [expr {$env(TMPDIR) eq $original_tmpdir}]
 } -cleanup {
     rename exec {}
     rename exec_real exec
@@ -60,7 +69,7 @@ test rustcache_start_server {
         }
     }
     namespace delete rust
-} -result {yes 1 {sccache --start-server >/dev/null}}
+} -result {yes 1 {sccache --start-server >/dev/null} 1 1}
 
 
 test rustcache_sandbox_profile {

--- a/src/port1.0/tests/portrustcache.test
+++ b/src/port1.0/tests/portrustcache.test
@@ -185,15 +185,29 @@ test rustcache_store_is_confined_to_a_subdirectory {
         proc $command {args} {}
     }
     rename exec exec_real
-    proc exec {args} {return {}}
+    # A failing start is what drives configure_start into disable_rustcache_environment,
+    # which is the code path that reveals the derived SCCACHE_DIR.
+    proc exec {args} {return -code error "sccache unavailable"}
+    # Seed the phase environments with both the subdirectory form and the flat form the
+    # store used to have. disable_rustcache_environment removes only the entries it would
+    # itself have added, with `lsearch -exact`, so which of the two it strips reveals the
+    # SCCACHE_DIR the code actually derives -- without this test having to name it.
+    foreach phase {configure build destroot} {
+        set ${phase}.env [list \
+            SCCACHE_DIR=[file join ${rustcache_dir} sccache] \
+            SCCACHE_DIR=${rustcache_dir}]
+    }
 } -body {
     portconfigure::configure_start
-    set store [file join $rustcache_dir sccache]
+    # The failing exec stub disables the cache, which runs disable_rustcache_environment.
+    set survivors ${configure.env}
+    set store [string range [lindex $survivors 0] [string length SCCACHE_DIR=] end]
     list \
-        [expr {$store ne $rustcache_dir}] \
-        [file isdirectory $store] \
-        [expr {[string first "${store}/" "${vendor_dir}/"] == 0}] \
-        [expr {[string first "${store}/" "${compwrap_dir}/"] == 0}]
+        [llength $survivors] \
+        [expr {$store eq $rustcache_dir}] \
+        [file isdirectory [file join $rustcache_dir sccache]] \
+        [expr {[string first "[file join $rustcache_dir sccache]/" "${vendor_dir}/"] == 0}] \
+        [expr {[string first "[file join $rustcache_dir sccache]/" "${compwrap_dir}/"] == 0}]
 } -cleanup {
     rename exec {}
     rename exec_real exec
@@ -204,7 +218,7 @@ test rustcache_store_is_confined_to_a_subdirectory {
         }
     }
     namespace delete rust
-} -result {1 1 0 0}
+} -result {1 1 1 0 0}
 
 
 cleanupTests

--- a/tests/test-macports.conf
+++ b/tests/test-macports.conf
@@ -18,3 +18,4 @@ extra_env               ENVA ENVB TCLLIBPATH DARWINTRACE_SIP_WORKAROUND_PATH MAC
 
 # Disable ccache for tests
 configureccache         no
+configurerustcache      no


### PR DESCRIPTION
Implements the base side of #58. Adds opt-in shared `sccache` configuration, lifecycle, sandbox/trace, reclaim, documentation, and tests. Companion macports-ports-dev PR #29 wires the Rust PortGroups.

Validation:

- rebased head `202f19592` onto the merged #77/#78/#80 base; range-diff confirms the six Rust-cache commits are semantically unchanged
- exact rebased branch: clean configure/build and full `make test` pass
- exact rebased GitHub Actions: 10/10 checks pass
- `macports.test` Rust-cache cases: 2 passed
- full `reclaim.test`: 7 passed, including server-stop ordering and deletion
- `portrustcache.test`: 3 passed, including startup failure rollback
- isolated combined scratch prefix: 4/4 fixture ports indexed
- cold cacheable Rust library build: 1 Rust miss
- identical rebuild: 1 Rust hit, 50% cumulative hit rate
- clean lifecycle restart build: 1 Rust hit, 0 misses, 100% run hit rate

The lifecycle starts `sccache` with `TMPDIR` set to the cache directory, avoiding `SUN_LEN` failures caused by MacPorts' long phase temporary path while restoring the original `TMPDIR` afterward. If directory creation or server startup fails, all five injected cache environment entries are removed so the build continues uncached. `port reclaim` best-effort stops the configured server before deleting its socket and cache contents.

The merged #77 exposed a separate worker-interpreter regression while resolving `build.jobs`; it is fixed and mutation-tested in #84. The compiler-resource safe-parser compatibility blocker is isolated in macports-ports-dev#32. Neither is caused by this Rust-cache delta, but both must be layered into the final empty-prefix integration run.

Independent review passes for this rebased head and for #32; #84's reviewer finding is resolved and its re-review passes. Draft pending #84 and the final distinct-port `rtk` → `mcpls` cache-reuse measurement.


---

## Deployment lockstep (raised in review, 2026-09-06)

`SCCACHE_DIR` moved from `${rustcache_dir}` to `${rustcache_dir}/sccache`, and base removes those
phase-environment entries with `lsearch -exact`. The exact string must therefore match on both
sides, so **eejd/macports-base#79 and eejd/macports-ports-dev#29 have to land together.** With a
new base and an old PortGroup the old key goes unstripped; with an old base and a new PortGroup
the new key does. Neither is deployed to `/opt/local` today, so there is no live skew to manage —
only a sequencing requirement when they are.

Reverting either one alone reintroduces the skew, so a rollback has to take both.