### PR TITLE
Fix out-of-tree install helper path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,17 @@ jobs:
             # Extra dep for building HTML man pages.
             sudo apt install --no-install-recommends asciidoc-base
           fi
+      - name: Test VPATH install helper
+        if: startsWith(matrix.os,'macos')
+        run: |
+          set -eu
+          mkdir vpath-build
+          cd vpath-build
+          ../configure --without-startupitems
+          make -C vendor all-install
+          install_path=$(awk '$1 == "INSTALL" { print $3 }' Mk/macports.autoconf.mk)
+          test "$install_path" = "$PWD/vendor/install/build/install"
+          test -x "$install_path"
       - name: Configure MacPorts Base
         run: |
           set -eu
@@ -61,17 +72,6 @@ jobs:
         run: |
           set -eu
           make test
-      - name: Test VPATH install helper
-        if: startsWith(matrix.os,'macos')
-        run: |
-          set -eu
-          mkdir vpath-build
-          cd vpath-build
-          ../configure --without-startupitems
-          make -C vendor all-install
-          install_path=$(awk '$1 == "INSTALL" { print $3 }' Mk/macports.autoconf.mk)
-          test "$install_path" = "$PWD/vendor/install/build/install"
-          test -x "$install_path"
       - name: Install MacPorts Base
         run: |
           set -eu

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,17 @@ jobs:
         run: |
           set -eu
           make test
+      - name: Test VPATH install helper
+        if: startsWith(matrix.os,'macos')
+        run: |
+          set -eu
+          mkdir vpath-build
+          cd vpath-build
+          ../configure --without-startupitems
+          make -C vendor all-install
+          install_path=$(awk '$1 == "INSTALL" { print $3 }' Mk/macports.autoconf.mk)
+          test "$install_path" = "$PWD/vendor/install/build/install"
+          test -x "$install_path"
       - name: Install MacPorts Base
         run: |
           set -eu

--- a/configure
+++ b/configure
@@ -8004,7 +8004,7 @@ if test x$ac_cv_func_clonefile = xyes -a x$ac_cv_have_decl_CLONE_NOOWNERCOPY = x
 ac_config_files="$ac_config_files vendor/install/Makefile"
 
 # If we build it, also use to install our own files.
-INSTALL="`(cd vendor; pwd)`/install/build/install"
+INSTALL="`pwd`/vendor/install/build/install"
 fi
 
 # Check for library functions, replacements are in pextlib1.0/compat/
@@ -11570,5 +11570,4 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
   { printf '%s\n' "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
 printf '%s\n' "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
-
 

--- a/configure.ac
+++ b/configure.ac
@@ -285,7 +285,7 @@ AC_SUBST(HAVE_DECL_CLONE_NOOWNERCOPY, $ac_cv_have_decl_CLONE_NOOWNERCOPY)
 if test x$ac_cv_func_clonefile = xyes -a x$ac_cv_have_decl_CLONE_NOOWNERCOPY = xyes; then
 AC_CONFIG_FILES([vendor/install/Makefile])
 # If we build it, also use to install our own files.
-INSTALL="`(cd vendor; pwd)`/install/build/install"
+INSTALL="`pwd`/vendor/install/build/install"
 fi
 
 # Check for library functions, replacements are in pextlib1.0/compat/


### PR DESCRIPTION
Fixes the narrow out-of-tree configure path for the vendored install helper. The previous expression resolved through a build-time `vendor` directory before it existed and generated the wrong helper path.

Validation:

- all 10 GitHub Actions checks pass across macOS 14, macOS 15, macOS 26, and Ubuntu
- the macOS VPATH smoke configures from an empty build directory before any in-tree build can contaminate the result
- it builds `vendor/all-install`, asserts the exact build-tree `INSTALL` path, and asserts that helper is executable
- the same exact-path assertion fails against the parent behavior
- independent delta review: PASS at head `1464f973e`

Related #82 tracks broader vendored-dependency and test-launcher VPATH assumptions. This PR deliberately does not close that issue.
