### PR TITLE
Expose parallel job calculation to Portfile workers

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -2187,6 +2187,7 @@ proc macports::worker_init {workername portpath porturl portbuildpath options va
     $workername alias binaryInPath macports::binaryInPath
     $workername alias find_tar_with_hfscompression macports::find_tar_with_hfscompression
     $workername alias sysctl sysctl
+    $workername alias macports::get_parallel_jobs macports::get_parallel_jobs
     $workername alias realpath realpath
     $workername alias _mportsearchpath _mportsearchpath
     $workername alias _portnameactive _portnameactive

--- a/src/macports1.0/tests/macports.test
+++ b/src/macports1.0/tests/macports.test
@@ -12,6 +12,24 @@ source $macports::autoconf::top_srcdir/src/macports1.0/tests/test_setup.tcl
 package require Thread
 
 
+test worker_parallel_jobs_default {
+    The build.jobs default can call the shared job calculator from a Portfile worker.
+} -setup {
+    set mport [mportopen file://${pwd}]
+    set workername [ditem_key $mport workername]
+} -body {
+    set jobs [$workername eval {
+        set buildmakejobs 0
+        set use_parallel_build yes
+        set build.mem_per_job 1024
+        portbuild::build_getjobs
+    }]
+    expr {[string is integer -strict $jobs] && $jobs >= 1}
+} -cleanup {
+    mportclose $mport
+} -result 1
+
+
 test mportclose {
     Mport close unit test.
 } -setup {

--- a/src/port1.0/tests/portbuild.test
+++ b/src/port1.0/tests/portbuild.test
@@ -23,6 +23,11 @@ set build_getjobs_fixture_setup {
     set use_parallel_build yes
     set build.mem_per_job 1024
 
+    set _macports_buildmakejobs ${::macports::buildmakejobs}
+    set _macports_os_platform ${::macports::os_platform}
+    set ::macports::buildmakejobs 0
+    set ::macports::os_platform darwin
+
     # Move away sysctl and replace it with our own implementation
     rename sysctl sysctl_backup
     proc sysctl {sysctlname} {
@@ -50,6 +55,8 @@ set build_getjobs_fixture_cleanup {
     # Restore modified state
     rename sysctl ""
     rename sysctl_backup sysctl
+    set ::macports::buildmakejobs ${_macports_buildmakejobs}
+    set ::macports::os_platform ${_macports_os_platform}
 }
 
 test build_getjobs_auto_cpubound {


### PR DESCRIPTION
Closes #83.

## Summary

- expose the shared parallel-job calculator to safe Portfile workers
- cover `build.jobs` default evaluation through a real worker interpreter
- update the #77 test fixture to control the master-interpreter state now used by the helper

## Root cause

#77 moved automatic job calculation to `macports::get_parallel_jobs`. `portbuild::build_getjobs` calls that qualified command, including while resolving the `build.jobs` default in a Portfile worker, but `macports::worker_init` did not alias the command into that worker.

## Validation

- clean configure and `make -j8`: pass
- full clean-tree `make test`: pass
- GitHub Actions: 10/10 pass
- `src/macports1.0`: 50 total, 41 passed, 9 root/VCS-constrained, 0 failed
- `src/port1.0`: `portbuild.test` 11/11 passed; all reported suite failures 0
- mutation check: the new worker test fails with `invalid command name "macports::get_parallel_jobs"` when the alias is removed and passes when restored

Independent review's false-negative test finding is resolved: the test now directly invokes `portbuild::build_getjobs` in the worker, and re-review passes with no findings.
