### PR TITLE
Stop exporting the sccache settings to the process environment

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,12 @@ Release 2.13.0 (unreleased)
       rustcache_dir, so that other shared Rust build state kept alongside
       it is outside sccache's LRU eviction scope. (#58)
 
+    - Stopped exporting SCCACHE_DIR, SCCACHE_CACHE_SIZE and
+      SCCACHE_SERVER_UDS to the process environment. They were set even
+      when configurerustcache was no, naming a directory the build sandbox
+      grants only when it is yes. Nothing read them from the environment.
+      (#85)
+
     - Added a --purge option for 'port clean' that quickly and
       unconditionally deletes all files of the chosen type(s).
       (jmr in 22e1abd)

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -1994,13 +1994,15 @@ match macports.conf.default."
     # add ccache to environment
     set env(CCACHE_DIR) $ccache_dir
 
-    # Add the Rust compiler cache settings to the process environment.
-    # SCCACHE_DIR is a subdirectory of rustcache_dir, not rustcache_dir itself:
-    # sccache's LRU evicts everything it finds under SCCACHE_DIR, and the shared
-    # vendor tree and linker wrappers are siblings of the object store.
-    set env(SCCACHE_DIR) [file join $rustcache_dir sccache]
-    set env(SCCACHE_CACHE_SIZE) $rustcache_size
-    set env(SCCACHE_SERVER_UDS) [file join $rustcache_dir sccache.sock]
+    # The sccache settings are deliberately NOT exported here. Nothing in base
+    # reads them from the environment: the Rust PortGroup puts them in its own
+    # configure.env/build.env/destroot.env, and the two places base runs sccache
+    # itself pass them explicitly on the command line. Exporting them from here
+    # would put SCCACHE_DIR in every build's environment even when
+    # configurerustcache is no -- naming a directory the sandbox only grants
+    # write access to when it is yes. A build that finds sccache on its own then
+    # walks into a denied write, which is the failure mode ccache has already hit
+    # twice. See #85.
 
     # load caches on demand
     trace add variable macports::compiler_version_cache read macports::load_compiler_version_cache

--- a/src/macports1.0/tests/macports.test
+++ b/src/macports1.0/tests/macports.test
@@ -31,8 +31,17 @@ test worker_parallel_jobs_default {
 
 
 test rustcache_defaults {
-    Rust compiler cache options have safe defaults and bootstrap metadata.
+    Rust compiler cache options have safe defaults and bootstrap metadata,
+    and mportinit exports none of them to the process environment.
 } -body {
+    # The three `info exists` checks are the regression guard for #85. mportinit
+    # used to export these unconditionally, which put SCCACHE_DIR in every
+    # build's environment even with configurerustcache no -- naming a directory
+    # the sandbox only grants when it is yes. Nothing in base reads them from the
+    # environment, so they are simply not exported now; the PortGroup sets its
+    # own phase env and base's own sccache invocations pass them on the command
+    # line. Assumes the test runner's own environment does not set them, which is
+    # true wherever mportinit is what would have.
     list \
         $macports::configurerustcache \
         $macports::rustcache_dir \
@@ -40,9 +49,9 @@ test rustcache_defaults {
         [dict exists $macports::bootstrap_options configurerustcache] \
         [dict get $macports::bootstrap_options rustcache_dir is_path] \
         [dict exists $macports::bootstrap_options rustcache_size] \
-        $::env(SCCACHE_DIR) \
-        $::env(SCCACHE_CACHE_SIZE) \
-        $::env(SCCACHE_SERVER_UDS)
+        [info exists ::env(SCCACHE_DIR)] \
+        [info exists ::env(SCCACHE_CACHE_SIZE)] \
+        [info exists ::env(SCCACHE_SERVER_UDS)]
 } -result [list \
     no \
     [file join $pwd tmpdir var macports build .rustcache] \
@@ -50,9 +59,9 @@ test rustcache_defaults {
     1 \
     1 \
     1 \
-    [file join $pwd tmpdir var macports build .rustcache sccache] \
-    20G \
-    [file join $pwd tmpdir var macports build .rustcache sccache.sock]]
+    0 \
+    0 \
+    0]
 
 
 test rustcache_cli_override {

--- a/src/macports1.0/tests/macports.test
+++ b/src/macports1.0/tests/macports.test
@@ -7,6 +7,14 @@ namespace import tcltest::*
 set pwd [file dirname [file normalize $argv0]]
 
 source ../macports_test_autoconf.tcl
+
+# Clear any ambient sccache settings before test_setup.tcl calls mportinit, so
+# rustcache_defaults below measures what mportinit does rather than what the
+# invoking shell happened to export. It has to happen here rather than in that
+# test's -setup, which runs long after mportinit has already had its chance. See
+# #85.
+unset -nocomplain ::env(SCCACHE_DIR) ::env(SCCACHE_CACHE_SIZE) ::env(SCCACHE_SERVER_UDS)
+
 source $macports::autoconf::top_srcdir/src/macports1.0/tests/test_setup.tcl
 
 package require Thread
@@ -40,8 +48,9 @@ test rustcache_defaults {
     # the sandbox only grants when it is yes. Nothing in base reads them from the
     # environment, so they are simply not exported now; the PortGroup sets its
     # own phase env and base's own sccache invocations pass them on the command
-    # line. Assumes the test runner's own environment does not set them, which is
-    # true wherever mportinit is what would have.
+    # line. The three are unset at the top of this file, before mportinit runs,
+    # so a developer with sccache in their own environment does not see a
+    # spurious failure here.
     list \
         $macports::configurerustcache \
         $macports::rustcache_dir \

--- a/src/port1.0/portconfigure_run.tcl
+++ b/src/port1.0/portconfigure_run.tcl
@@ -99,7 +99,7 @@ proc configure_start {args} {
     }
 
     if {${configure.rustcache} && [namespace exists ::rust]} {
-        global rustcache_dir macportsuser
+        global rustcache_dir rustcache_size macportsuser prefix
         elevateToRoot "configure rust cache"
         # The sccache object store is deliberately confined to a subdirectory:
         # sccache's LRU walks its whole SCCACHE_DIR and evicts anything it finds
@@ -124,7 +124,17 @@ proc configure_start {args} {
                     }
                     set ::env(TMPDIR) ${rustcache_dir}
                     try {
-                        exec sccache --start-server >/dev/null
+                        # Pass the cache settings explicitly rather than relying
+                        # on the process environment -- mportinit no longer
+                        # exports them (#85), and the server would otherwise come
+                        # up against sccache's own default cache directory
+                        # instead of rustcache_dir. Same form as reclaim.tcl's
+                        # --stop-server.
+                        exec env \
+                            SCCACHE_DIR=[file join ${rustcache_dir} sccache] \
+                            SCCACHE_CACHE_SIZE=${rustcache_size} \
+                            SCCACHE_SERVER_UDS=[file join ${rustcache_dir} sccache.sock] \
+                            [file join ${prefix} bin sccache] --start-server >/dev/null
                     } finally {
                         if {${had_tmpdir}} {
                             set ::env(TMPDIR) ${saved_tmpdir}

--- a/src/port1.0/tests/portrustcache.test
+++ b/src/port1.0/tests/portrustcache.test
@@ -57,7 +57,7 @@ test rustcache_start_server {
         ${configure.rustcache} \
         [file isdirectory $rustcache_dir] \
         [file isdirectory [file join $rustcache_dir sccache]] \
-        $sccache_command \
+        [string map [list $rustcache_dir @DIR@] $sccache_command] \
         [expr {$sccache_tmpdir eq $rustcache_dir}] \
         [expr {$env(TMPDIR) eq $original_tmpdir}]
 } -cleanup {
@@ -70,7 +70,7 @@ test rustcache_start_server {
         }
     }
     namespace delete rust
-} -result {yes 1 1 {sccache --start-server >/dev/null} 1 1}
+} -result {yes 1 1 {env SCCACHE_DIR=@DIR@/sccache SCCACHE_CACHE_SIZE=rustcache_size SCCACHE_SERVER_UDS=@DIR@/sccache.sock prefix/bin/sccache --start-server >/dev/null} 1 1}
 
 
 test rustcache_start_failure_disables_wrapper {


### PR DESCRIPTION
Closes #85.

`mportinit` set `SCCACHE_DIR`, `SCCACHE_CACHE_SIZE` and `SCCACHE_SERVER_UDS` unconditionally, while the sandbox grant for `rustcache_dir` is conditional (`portsandbox.tcl:92-94`, `:170-172`). With `configurerustcache no` — the default — every build ran with `SCCACHE_DIR` naming a directory the sandbox denies writes to. A build system that finds sccache itself rather than through MacPorts then walks into a denied write: the failure mode ccache has already hit twice (macports-ports-local#650, #648, #372).

## Removed rather than guarded

Nothing in base read these from the environment. The Rust PortGroup sets its own `configure.env`/`build.env`/`destroot.env` (`rust-1.0.tcl:624-653`), `reclaim.tcl:219-220` builds an explicit `exec env` argv, and `portconfigure_run.tcl:11-29` only knows how to *strip* them. A full-tree grep found the sole reader was a test.

Deleting beats guarding here: no conditional to get wrong, and it closes the gap the guard could not. The sandbox and trace grants are conditioned on `${configure.rustcache} && [namespace exists ::rust]` — a two-part condition `mportinit` could never mirror, since the `::rust` namespace belongs to the Portfile interpreter. A `configurerustcache`-only guard would still have leaked the variable to non-Rust ports whenever the option was globally on. Removing the export makes that asymmetry moot.

## One caller did rely on the inheritance

Worth flagging, because it would have failed silently. `exec sccache --start-server` in `portconfigure_run.tcl` set only `TMPDIR` explicitly and took the rest from the process environment. Without the export the server would still have started — just against sccache's own default cache directory instead of `rustcache_dir`, with no error anywhere.

It now passes all three on the command line, in the same form `reclaim.tcl` already uses for `--stop-server`, and addresses sccache by absolute path instead of through `PATH`. That second part is a deliberate change beyond the minimum: it matches the sibling call site and the `RUSTC_WRAPPER=${prefix}/bin/sccache` the PortGroup sets, and `depends_build port:sccache` guarantees the binary is there.

## Tests

`rustcache_defaults` now asserts the three variables are **absent**, converting it from a presence check into a regression guard for this issue. Per the "a test must be seen to fail" rule, I verified it against the pre-fix state by reinstating the export:

| state | `macports.test` |
|---|---|
| export reinstated | 52 total, **42 passed, 1 failed** |
| this branch | 52 total, **43 passed, 0 failed** |

`rustcache_start_server` pins the new argv, with the temp directory normalised to `@DIR@` via `string map` so the assertion stays exact rather than being loosened to a substring match.

| suite | result |
|---|---|
| `src/macports1.0` `macports.test` | 52 total, 43 passed, 9 skipped (root/svn), **0 failed** |
| `src/macports1.0` `reclaim.test` | 7/7 |
| `src/port1.0` `portrustcache.test` | 4/4 |
| both suites, all files | **0 failures** |

`CCACHE_DIR` at `macports.tcl:1995` is deliberately left alone — it has a real consumer at `porttrace.tcl:265-270`, and `configureccache` defaults to `yes` on the nodes here, so its export and its grant agree in the common case. That asymmetry in defaults is what made the sccache copy of the pattern a live hazard rather than a latent one.
